### PR TITLE
Use exporters functionally

### DIFF
--- a/Mischief.js
+++ b/Mischief.js
@@ -7,7 +7,6 @@
 import { chromium } from "playwright";
 import ProxyServer from "transparent-proxy";
 
-import * as exporters from "./exporters/index.js";
 import { MischiefExchange } from "./MischiefExchange.js";
 import { MischiefLog } from "./MischiefLog.js";
 import { MischiefOptions } from "./MischiefOptions.js";
@@ -356,22 +355,4 @@ export class Mischief {
 
     return options;
   }
-
-  /**
-   * Export capture to WARC.
-   * @param {boolean} [gzip=false] - If `true`, will be compressed using GZIP (for `.warc.gz`). 
-   * @returns {Promise<ArrayBuffer>} - Binary data ready to be saved a .warc or .warc.gz
-   */
-  async toWarc(gzip=false) {
-    return await exporters.warc(this, gzip);
-  }
-
-  /**
-   * Export capture to WACZ.
-   * @returns {Promise<ArrayBuffer>} - Binary data ready to be saved a .wacz
-   */
-  async toWacz() {
-    return await exporters.wacz(this);
-  }
-
 }

--- a/example.js
+++ b/example.js
@@ -1,7 +1,7 @@
 // [!] Example file -- to be deleted at earliest convenience.
-import crypto from "crypto";
 import { mkdir, writeFile } from "fs/promises";
 import { Mischief } from "./Mischief.js";
+import * as exporters from "./exporters/index.js";
 
 const toCapture = [
   {name: "google", url: "https://google.com"},
@@ -31,18 +31,18 @@ const path = "./examples/";
 try {
   await mkdir(path);
 }
-catch(err) {
+catch(_err) {
 }
 
-for (let entry of toCapture) {
-  let {name, url} = entry;
+for (const entry of toCapture) {
+  const {name, url} = entry;
 
   const myCapture = new Mischief(url);
   await myCapture.capture();
 
   const format = "wacz";
   const filename = `${path}${name}.${format}`;
-  const data = await myCapture[`to${format.charAt(0).toUpperCase() + format.slice(1)}`]();
+  const data = await exporters[format](myCapture);
   await writeFile(filename, Buffer.from(data));
 
   console.log(`💾 Saved ${url} as ${filename}`);

--- a/exporters/wacz.js
+++ b/exporters/wacz.js
@@ -5,6 +5,7 @@ import { v4 as uuidv4 } from "uuid";
 import { spawn  } from "child_process";
 
 import { Mischief } from "../Mischief.js";
+import * as exporters from "../exporters/index.js";
 
 /**
  * Mischief to WACZ converter.
@@ -32,7 +33,7 @@ export async function wacz(capture) {
                        {id: uuidv4(), url: capture.url, title: "", seed: true}].map(JSON.stringify).join('\n');
     await writeFile(pagesFile, pagesData);
 
-    const warc = await capture.toWarc();
+    const warc = await exporters.warc(capture);
     await writeFile(warcFile, Buffer.from(warc));
 
     const createArgs = ["create", "--split-seeds", "-o", waczFile, "--pages", pagesFile, warcFile];


### PR DESCRIPTION
This will prevent us from needing to maintain a list of corresponding methods in Mischief as our exporters expand.