### PR TITLE
Use Standard JS?

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,0 @@
-{
-  "tabWidth": 2,
-  "printWidth": 100
-}
-

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "standard.vscode-standard"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "standard.autoFixOnSave": true
+}

--- a/Mischief.js
+++ b/Mischief.js
@@ -5,50 +5,50 @@
  * @license MIT
  */
 
-import os from "os";
-import util from "util";
-import { readFile, writeFile, rm, readdir, mkdir, mkdtemp, access } from "fs/promises";
-import { constants as fsConstants } from 'node:fs';
+import os from 'os'
+import util from 'util'
+import { readFile, writeFile, rm, readdir, mkdir, mkdtemp, access } from 'fs/promises'
+import { constants as fsConstants } from 'node:fs'
 
-import { exec as execCB } from "child_process";
-const exec = util.promisify(execCB);
+import { exec as execCB } from 'child_process'
 
-import log from "loglevel";
-import logPrefix from "loglevel-plugin-prefix";
-import nunjucks from "nunjucks";
-import ipAddressValidator from "ip-address-validator";
-import { v4 as uuidv4 } from "uuid";
-import { chromium } from "playwright";
-import { getOSInfo } from "get-os-info";
+import log from 'loglevel'
+import logPrefix from 'loglevel-plugin-prefix'
+import nunjucks from 'nunjucks'
+import ipAddressValidator from 'ip-address-validator'
+import { v4 as uuidv4 } from 'uuid'
+import { chromium } from 'playwright'
+import { getOSInfo } from 'get-os-info'
 
-import { MischiefGeneratedExchange } from "./exchanges/index.js";
-import { MischiefOptions } from "./MischiefOptions.js";
-import CONSTANTS from "./constants.js";
-import * as intercepters from "./intercepters/index.js";
-import * as exporters from "./exporters/index.js";
-import * as importers from "./importers/index.js";
+import { MischiefGeneratedExchange } from './exchanges/index.js'
+import { MischiefOptions } from './MischiefOptions.js'
+import CONSTANTS from './constants.js'
+import * as intercepters from './intercepters/index.js'
+import * as exporters from './exporters/index.js'
+import * as importers from './importers/index.js'
+const exec = util.promisify(execCB)
 
 /**
- * Path to "assets" folder. 
+ * Path to "assets" folder.
  * @constant
  */
-export const ASSETS_DIR = `./assets/`;
+export const ASSETS_DIR = './assets/'
 
 /**
  * Experimental single-page web archiving library using Playwright.
  * Uses a proxy to allow for comprehensive and raw network interception.
- * 
+ *
  * Usage:
  * ```javascript
  * import { Mischief } from "mischief";
- * 
+ *
  * const myCapture = new Mischief("https://example.com");
  * await myCapture.capture();
  * const myArchive = await myCapture.toWarc();
  * ```
  */
 export class Mischief {
-  id = uuidv4();
+  id = uuidv4()
 
   /**
    * Enum-like states that the capture occupies.
@@ -62,104 +62,104 @@ export class Mischief {
     COMPLETE: 3,
     PARTIAL: 4,
     FAILED: 5
-  };
+  }
 
   /**
    * Current state of the capture.
    * Should only contain states defined in `states`.
    * @type {number}
    */
-  state = Mischief.states.INIT;
+  state = Mischief.states.INIT
 
   /**
    * URL to capture.
-   * @type {string} 
+   * @type {string}
    */
-  url = "";
+  url = ''
 
-  /** 
-   * Current settings. 
+  /**
+   * Current settings.
    * Should only contain keys defined in `MischiefOptions`.
-   * @type {object} 
+   * @type {object}
    */
-  options = {};
+  options = {}
 
   /**
    * Array of HTTP exchanges that constitute the capture.
    * @type {MischiefExchange[]}
    */
-  exchanges = [];
+  exchanges = []
 
   /**
    * Logger.
-   * Logging level controlled via `MischiefOptions.logLevel`. 
-   * @type {?log.Logger} 
+   * Logging level controlled via `MischiefOptions.logLevel`.
+   * @type {?log.Logger}
    */
-  log = log;
+  log = log
 
   /**
    * Path to the capture-specific temporary folder created by `setup()`.
    * Will be a child folder of the path defined in `this.options.tmpFolderPath`.
    * @type {?string}
    */
-  captureTmpFolderPath = null;
+  captureTmpFolderPath = null
 
   /**
    * The time at which the page was crawled.
    * @type {Date}
    */
-  startedAt;
+  startedAt
 
   /**
    * The Playwright browser instance for this capture.
    * @type {Browser}
    */
-  #browser;
+  #browser
 
   /**
    * Reference to the intercepter chosen for capture.
    * @type {intercepters.MischiefIntercepter}
    */
-  intercepter;
+  intercepter
 
   /**
    * Will only be populated if `options.provenanceSummary` is `true`.
    * @type {object}
    */
-  provenanceInfo = {};
+  provenanceInfo = {}
 
   /**
    * @param {string} url - Must be a valid HTTP(S) url.
    * @param {object} [options={}] - See `MischiefOptions.defaults` for details.
    */
-  constructor(url, options = {}) {
-    this.url = this.filterUrl(url);
-    this.options = MischiefOptions.filterOptions(options);
+  constructor (url, options = {}) {
+    this.url = this.filterUrl(url)
+    this.options = MischiefOptions.filterOptions(options)
 
     // Logging setup (level, output formatting)
-    logPrefix.reg(this.log);    
+    logPrefix.reg(this.log)
     logPrefix.apply(log, {
-      format(level, name, timestamp) {
-        const timestampColor = CONSTANTS.LOGGING_COLORS.DEFAULT;
-        const msgColor = CONSTANTS.LOGGING_COLORS[level.toUpperCase()];
-        return `${timestampColor(`[${timestamp}]`)} ${msgColor(level)}`;
-      },
-    });
-    this.log.setLevel(this.options.logLevel);
+      format (level, name, timestamp) {
+        const timestampColor = CONSTANTS.LOGGING_COLORS.DEFAULT
+        const msgColor = CONSTANTS.LOGGING_COLORS[level.toUpperCase()]
+        return `${timestampColor(`[${timestamp}]`)} ${msgColor(level)}`
+      }
+    })
+    this.log.setLevel(this.options.logLevel)
 
-    this.intercepter = new intercepters[this.options.intercepter](this);
+    this.intercepter = new intercepters[this.options.intercepter](this)
   }
 
   /**
    * Main capture process.
-   *   
+   *
    * @returns {Promise<boolean>}
    */
-  async capture() {
-    const options = this.options;
+  async capture () {
+    const options = this.options
 
     /** @type {{name: String, setup: ?function, main: function}[]} */
-    const steps = []; 
+    const steps = []
 
     //
     // Prepare capture steps
@@ -167,19 +167,19 @@ export class Mischief {
 
     // Push step: Setup interceptor
     steps.push({
-      name: "Intercepter",
+      name: 'Intercepter',
       main: async (page) => {
-        await this.intercepter.setup(page);
+        await this.intercepter.setup(page)
       }
     })
 
     // Push step: Initial page load
     steps.push({
-      name: "Initial page load",
+      name: 'Initial page load',
       main: async (page) => {
-        await page.goto(this.url, { waitUntil: "load", timeout: options.loadTimeout });
+        await page.goto(this.url, { waitUntil: 'load', timeout: options.loadTimeout })
       }
-    });
+    })
 
     // Push step: Browser scripts
     if (
@@ -189,11 +189,11 @@ export class Mischief {
       options.autoScroll
     ) {
       steps.push({
-        name: "Browser scripts",
+        name: 'Browser scripts',
         setup: async (page) => {
           await page.addInitScript({
-            path: "./node_modules/browsertrix-behaviors/dist/behaviors.js",
-          });
+            path: './node_modules/browsertrix-behaviors/dist/behaviors.js'
+          })
           await page.addInitScript({
             content: `
               self.__bx_behaviors.init({
@@ -202,140 +202,137 @@ export class Mischief {
                 autoscroll: ${options.autoScroll},
                 siteSpecific: ${options.runSiteSpecificBehaviors},
                 timeout: ${options.behaviorsTimeout}
-              });`,
-          });
+              });`
+          })
         },
         main: async (page) => {
           await Promise.allSettled(
-            page.frames().map((frame) => frame.evaluate("self.__bx_behaviors.run()"))
-          );
-        },
-      });
+            page.frames().map((frame) => frame.evaluate('self.__bx_behaviors.run()'))
+          )
+        }
+      })
     }
 
     // Push step: Wait for network idle
     steps.push({
-      name: "Wait for network idle",
+      name: 'Wait for network idle',
       main: async (page) => {
-        await page.waitForLoadState("networkidle", {timeout: options.networkIdleTimeout});
+        await page.waitForLoadState('networkidle', { timeout: options.networkIdleTimeout })
       }
-    });
+    })
 
     // Push step: Screenshot
     if (options.screenshot) {
       steps.push({
-        name: "Screenshot",
+        name: 'Screenshot',
         main: async (page) => {
-          const url = "file:///screenshot.png";
-          const httpHeaders = { "content-type": "image/png" };
-          const body = await page.screenshot({ fullPage: true });
-          const isEntryPoint = true;
-          const description = `Capture Time Screenshot of ${this.url}`;
-          this.addGeneratedExchange(url, httpHeaders, body, isEntryPoint, description);
+          const url = 'file:///screenshot.png'
+          const httpHeaders = { 'content-type': 'image/png' }
+          const body = await page.screenshot({ fullPage: true })
+          const isEntryPoint = true
+          const description = `Capture Time Screenshot of ${this.url}`
+          this.addGeneratedExchange(url, httpHeaders, body, isEntryPoint, description)
         }
-      });
+      })
     }
 
     // Push step: DOM Snapshot
     if (options.domSnapshot) {
       steps.push({
-        name: "DOM snapshot",
+        name: 'DOM snapshot',
         main: async (page) => {
-          const url = "file:///dom-snapshot.html";
+          const url = 'file:///dom-snapshot.html'
           const httpHeaders = {
-            "content-type": "text/html",
-            "content-disposition": "Attachment",
-          };
-          const body = Buffer.from(await page.content());
-          const isEntryPoint = true;
-          const description = `Capture Time DOM Snapshot of ${this.url}`;
+            'content-type': 'text/html',
+            'content-disposition': 'Attachment'
+          }
+          const body = Buffer.from(await page.content())
+          const isEntryPoint = true
+          const description = `Capture Time DOM Snapshot of ${this.url}`
 
-          this.addGeneratedExchange(url, httpHeaders, body, isEntryPoint, description);
+          this.addGeneratedExchange(url, httpHeaders, body, isEntryPoint, description)
         }
-      });
+      })
     }
 
     // Push step: PDF Snapshot
     if (options.pdfSnapshot) {
       steps.push({
-        name: "PDF snapshot",
+        name: 'PDF snapshot',
         main: async (page) => {
-          await this.#takePdfSnapshot(page);
+          await this.#takePdfSnapshot(page)
         }
-      });
+      })
     }
 
     // Push step: Capture of in-page videos as attachment
     if (options.captureVideoAsAttachment) {
       steps.push({
-        name: "Out-of-browser capture of video as attachment",
+        name: 'Out-of-browser capture of video as attachment',
         main: async () => {
-          await this.#captureVideoAsAttachment();
+          await this.#captureVideoAsAttachment()
         }
-      });
+      })
     }
 
     // Push step: Provenance summary
     if (options.provenanceSummary) {
       steps.push({
-        name: "Provenance summary",
+        name: 'Provenance summary',
         main: async (page) => {
-          await this.#captureProvenanceInfo(page);
+          await this.#captureProvenanceInfo(page)
         }
-      });
+      })
     }
 
     // Push step: Teardown
     steps.push({
-      name: "Teardown",
+      name: 'Teardown',
       main: async () => {
-        this.state = Mischief.states.COMPLETE;
-        await this.teardown();
+        this.state = Mischief.states.COMPLETE
+        await this.teardown()
       }
-    });
+    })
 
     //
     // Initialize capture
     //
-    let page;
+    let page
 
     try {
-      page = await this.setup();
-      this.log.info(`Starting capture of ${this.url}.`);
-      this.log.info(options);
-      this.state = Mischief.states.CAPTURE;
-    } 
-    catch (err) {
-      this.log.error("An error ocurred during capture setup.");
-      this.log.trace(err);
-      this.state = Mischief.states.FAILED;
-      return; // exit early if the browser and proxy couldn't be launched
+      page = await this.setup()
+      this.log.info(`Starting capture of ${this.url}.`)
+      this.log.info(options)
+      this.state = Mischief.states.CAPTURE
+    } catch (err) {
+      this.log.error('An error ocurred during capture setup.')
+      this.log.trace(err)
+      this.state = Mischief.states.FAILED
+      return // exit early if the browser and proxy couldn't be launched
     }
 
     //
     // Call `setup()` method of steps that have one
     //
     for (const step of steps.filter((step) => step.setup)) {
-      await step.setup(page);
+      await step.setup(page)
     }
 
     //
     // Run capture steps
     //
-    let i = -1;
-    while(i++ < steps.length-1 && this.state == Mischief.states.CAPTURE) {
-      const step = steps[i];
+    let i = -1
+    while (i++ < steps.length - 1 && this.state === Mischief.states.CAPTURE) {
+      const step = steps[i]
       try {
-        this.log.info(`STEP [${i+1}/${steps.length}]: ${step.name}`);
-        await step.main(page);
-      } 
-      catch(err) {
-        if(this.state == Mischief.states.CAPTURE){
-          this.log.warn(`STEP [${i+1}/${steps.length}]: ${step.name} - failed.`);
-          this.log.trace(err);
-        } 
-        else {
-          this.log.warn(`STEP [${i+1}/${steps.length}]: ${step.name} - ended due to max time or size reached.`);
+        this.log.info(`STEP [${i + 1}/${steps.length}]: ${step.name}`)
+        await step.main(page)
+      } catch (err) {
+        if (this.state === Mischief.states.CAPTURE) {
+          this.log.warn(`STEP [${i + 1}/${steps.length}]: ${step.name} - failed.`)
+          this.log.trace(err)
+        } else {
+          this.log.warn(`STEP [${i + 1}/${steps.length}]: ${step.name} - ended due to max time or size reached.`)
         }
       }
     }
@@ -346,96 +343,92 @@ export class Mischief {
    *
    * @returns {Promise<boolean>}
    */
-  async setup() {
-    this.startedAt = new Date();
-    this.state = Mischief.states.SETUP;
-    const options = this.options;
+  async setup () {
+    this.startedAt = new Date()
+    this.state = Mischief.states.SETUP
+    const options = this.options
 
     // Create "base" temporary folder if it doesn't exist
-    let tmpFolderPathExists = false;
+    let tmpFolderPathExists = false
     try {
-      await access(this.options.tmpFolderPath);
-      tmpFolderPathExists = true;
-    }
-    catch(_err) { 
-      this.log.info(`Base temporary folder ${this.options.tmpFolderPath} does not exist or cannot be accessed. Mischief will attempt to create it.`);
+      await access(this.options.tmpFolderPath)
+      tmpFolderPathExists = true
+    } catch (_err) {
+      this.log.info(`Base temporary folder ${this.options.tmpFolderPath} does not exist or cannot be accessed. Mischief will attempt to create it.`)
     }
 
     if (!tmpFolderPathExists) {
       try {
-        await mkdir(this.options.tmpFolderPath);
-        await access(this.options.tmpFolderPath, fsConstants.W_OK);
-        tmpFolderPathExists = true;
-      }
-      catch(err) {
-        this.log.warn(`Error while creating base temporary folder ${this.options.tmpFolderPath}.`);
-        this.log.trace(err);
+        await mkdir(this.options.tmpFolderPath)
+        await access(this.options.tmpFolderPath, fsConstants.W_OK)
+        tmpFolderPathExists = true
+      } catch (err) {
+        this.log.warn(`Error while creating base temporary folder ${this.options.tmpFolderPath}.`)
+        this.log.trace(err)
       }
     }
 
     // Create captures-specific temporary folder under base temporary folder
     try {
-      this.captureTmpFolderPath = await mkdtemp(this.options.tmpFolderPath);
-      this.captureTmpFolderPath += `/`;
-      await access(this.captureTmpFolderPath, fsConstants.W_OK);
+      this.captureTmpFolderPath = await mkdtemp(this.options.tmpFolderPath)
+      this.captureTmpFolderPath += '/'
+      await access(this.captureTmpFolderPath, fsConstants.W_OK)
 
-      this.log.info(`Capture-specific temporary folder ${this.captureTmpFolderPath} created.`);
-    }
-    catch(err) {
+      this.log.info(`Capture-specific temporary folder ${this.captureTmpFolderPath} created.`)
+    } catch (err) {
       try {
-        await rm(this.captureTmpFolderPath);
-      }
-      catch (err) { /* Ignore: Deletes the capture-specific folder if it was created, if possible. */ }
+        await rm(this.captureTmpFolderPath)
+      } catch (err) { /* Ignore: Deletes the capture-specific folder if it was created, if possible. */ }
 
-      throw new Error(`Mischief was unable to create a capture-specific temporary folder.\n${err}`);
+      throw new Error(`Mischief was unable to create a capture-specific temporary folder.\n${err}`)
     }
 
     // Playwright init
-    const userAgent = chromium._playwright.devices["Desktop Chrome"].userAgent + options.userAgentSuffix;
-    this.log.info(`User Agent used for capture: ${userAgent}`);
+    const userAgent = chromium._playwright.devices['Desktop Chrome'].userAgent + options.userAgentSuffix
+    this.log.info(`User Agent used for capture: ${userAgent}`)
 
     this.#browser = await chromium.launch({
       headless: options.headless,
-      channel: "chrome"
+      channel: 'chrome'
     })
 
-    const context = await this.#browser.newContext({ 
-      ...this.intercepter.contextOptions, 
-      userAgent: userAgent
-    });
+    const context = await this.#browser.newContext({
+      ...this.intercepter.contextOptions,
+      userAgent
+    })
 
-    const page = await context.newPage();
+    const page = await context.newPage()
 
     page.setViewportSize({
       width: options.captureWindowX,
-      height: options.captureWindowY,
-    });
+      height: options.captureWindowY
+    })
 
     const totalTimeoutTimer = setTimeout(() => {
-      this.log.info(`totalTimeout of ${options.totalTimeout}ms reached. Ending further capture.`);
-      this.state = Mischief.states.PARTIAL;
-      this.teardown();
-    }, options.totalTimeout);
+      this.log.info(`totalTimeout of ${options.totalTimeout}ms reached. Ending further capture.`)
+      this.state = Mischief.states.PARTIAL
+      this.teardown()
+    }, options.totalTimeout)
 
     this.#browser.on('disconnected', () => {
-      clearTimeout(totalTimeoutTimer);
-    });
+      clearTimeout(totalTimeoutTimer)
+    })
 
-    return page;
+    return page
   }
 
   /**
    * Tears down Playwright, intercepter resources, and capture-specific temporary folder.
    * @returns {Promise<boolean>}
    */
-  async teardown() {
-    this.log.info("Closing browser and intercepter.");
-    await this.intercepter.teardown();
-    await this.#browser.close();
-    this.exchanges = this.intercepter.exchanges.concat(this.exchanges);
+  async teardown () {
+    this.log.info('Closing browser and intercepter.')
+    await this.intercepter.teardown()
+    await this.#browser.close()
+    this.exchanges = this.intercepter.exchanges.concat(this.exchanges)
 
-    this.log.info(`Clearing capture-specific temporary folder ${this.captureTmpFolderPath}`);
-    await rm(this.captureTmpFolderPath, {recursive: true, force: true});
+    this.log.info(`Clearing capture-specific temporary folder ${this.captureTmpFolderPath}`)
+    await rm(this.captureTmpFolderPath, { recursive: true, force: true })
   }
 
   /**
@@ -443,39 +436,38 @@ export class Mischief {
    * - The "main" video of the current page (`file:///video-extracted.mp4`)
    * - Associated subtitles (`file:///video-extracted-LOCALE.EXT`)
    * - Associated meta data (`file:///video-extracted-metadata.json`)
-   * 
-   * These elements are added as "attachments" to the archive, for context / playback fallback purposes. 
+   *
+   * These elements are added as "attachments" to the archive, for context / playback fallback purposes.
    * A summary file and entry point, `file:///video-extracted-summary.html`, will be generated in the process.
-   * 
+   *
    * @private
    */
-  async #captureVideoAsAttachment() {
-    const id = this.id;
-    const videoFilename = `${this.captureTmpFolderPath}${id}.mp4`;
-    const ytDlpPath = this.options.ytDlpPath;
+  async #captureVideoAsAttachment () {
+    const id = this.id
+    const videoFilename = `${this.captureTmpFolderPath}${id}.mp4`
+    const ytDlpPath = this.options.ytDlpPath
 
-    let metadataRaw = null;
-    let metadataParsed = null;
+    let metadataRaw = null
+    let metadataParsed = null
 
-    const subtitlesAvailableLocales = [];
-    let subtitlesFormat = 'vtt';
-    let videoSaved = false;
-    let metadataSaved = false;
-    let subtitlesSaved = false;
+    const subtitlesAvailableLocales = []
+    let subtitlesFormat = 'vtt'
+    let videoSaved = false
+    let metadataSaved = false
+    let subtitlesSaved = false
 
     //
     // yt-dlp health check
     //
     try {
-      const result = await exec(`${ytDlpPath} --version`);
-      const version = result.stdout.trim();
+      const result = await exec(`${ytDlpPath} --version`)
+      const version = result.stdout.trim()
 
       if (!version.match(/^[0-9]{4}\.[0-9]{2}\.[0-9]{2}$/)) {
-        throw new Error(`Unknown version: ${version}`);
+        throw new Error(`Unknown version: ${version}`)
       }
-    }
-    catch(err) {
-      throw new Error(`"yt-dlp" executable is not available or cannot be executed. ${err}`);
+    } catch (err) {
+      throw new Error(`"yt-dlp" executable is not available or cannot be executed. ${err}`)
     }
 
     //
@@ -483,60 +475,57 @@ export class Mischief {
     //
     try {
       const dlpOptions = [
-        "--dump-json", // Will return JSON meta data via stdout
-        "--no-simulate", // Forces download despites `--dump-json`
-        "--no-warnings", // Prevents pollution of stdout
-        "--no-progress", // (Same as above)
-        "--write-subs", // Try to pull subs
-        "--sub-langs", "all", 
-        "--format", "mp4", // Forces .mp4 format
-        "--output", videoFilename,
+        '--dump-json', // Will return JSON meta data via stdout
+        '--no-simulate', // Forces download despites `--dump-json`
+        '--no-warnings', // Prevents pollution of stdout
+        '--no-progress', // (Same as above)
+        '--write-subs', // Try to pull subs
+        '--sub-langs', 'all',
+        '--format', 'mp4', // Forces .mp4 format
+        '--output', videoFilename,
         this.url
-      ];
+      ]
 
       const spawnOptions = {
-        timeout: this.options.captureVideoAsAttachmentTimeout,
-      };
+        timeout: this.options.captureVideoAsAttachmentTimeout
+      }
 
-      const result = await exec(`${ytDlpPath} ${dlpOptions.join(' ')}`, spawnOptions);
-      metadataRaw = result.stdout;
-    }
-    catch(_err) {
-      throw new Error(`No video found in ${this.url}.`); 
+      const result = await exec(`${ytDlpPath} ${dlpOptions.join(' ')}`, spawnOptions)
+      metadataRaw = result.stdout
+    } catch (_err) {
+      throw new Error(`No video found in ${this.url}.`)
     }
 
     //
     // Try to add video to exchanges
     //
     try {
-      const url = "file:///video-extracted.mp4";
-      const httpHeaders = { "content-type": "video/mp4" };
-      const body = await readFile(videoFilename);
-      const isEntryPoint = false; // TODO: Reconsider whether this should be an entry point.
+      const url = 'file:///video-extracted.mp4'
+      const httpHeaders = { 'content-type': 'video/mp4' }
+      const body = await readFile(videoFilename)
+      const isEntryPoint = false // TODO: Reconsider whether this should be an entry point.
 
-      this.addGeneratedExchange(url, httpHeaders, body, isEntryPoint);
-      videoSaved = true;
-    }
-    catch(err) {
-      throw new Error(`Error while creating exchange for file:///video-extracted.mp4. ${err}`);
+      this.addGeneratedExchange(url, httpHeaders, body, isEntryPoint)
+      videoSaved = true
+    } catch (err) {
+      throw new Error(`Error while creating exchange for file:///video-extracted.mp4. ${err}`)
     }
 
     //
     // Try to add metadata to exchanges
     //
     try {
-      metadataParsed = JSON.parse(metadataRaw); // May throw
+      metadataParsed = JSON.parse(metadataRaw) // May throw
 
-      const url = "file:///video-extracted-metadata.json";
-      const httpHeaders = { "content-type": "application/json" };
-      const body = Buffer.from(JSON.stringify(metadataParsed, null, 2));
-      const isEntryPoint = false;
+      const url = 'file:///video-extracted-metadata.json'
+      const httpHeaders = { 'content-type': 'application/json' }
+      const body = Buffer.from(JSON.stringify(metadataParsed, null, 2))
+      const isEntryPoint = false
 
-      this.addGeneratedExchange(url, httpHeaders, body, isEntryPoint);
-      metadataSaved = true;
-    }
-    catch(err) {
-      throw new Error(`Error while creating exchange for file:///video-extracted-medatadata.json. ${err}`);
+      this.addGeneratedExchange(url, httpHeaders, body, isEntryPoint)
+      metadataSaved = true
+    } catch (err) {
+      throw new Error(`Error while creating exchange for file:///video-extracted-medatadata.json. ${err}`)
     }
 
     //
@@ -544,39 +533,37 @@ export class Mischief {
     //
     try {
       for (const file of await readdir(this.captureTmpFolderPath)) {
-
         if (!file.startsWith(id)) {
-          continue;
+          continue
         }
-        
-        if (!file.endsWith(".vtt") && !file.endsWith(".srt")) {
-          continue;
+
+        if (!file.endsWith('.vtt') && !file.endsWith('.srt')) {
+          continue
         }
-  
-        let locale = null;
-        subtitlesFormat = "vtt";
-        [, locale, subtitlesFormat] = file.split(".");
+
+        let locale = null
+        subtitlesFormat = 'vtt';
+        [, locale, subtitlesFormat] = file.split('.')
 
         // Example of valid locales: "en", "en-US"
-        if (!locale.match(/^[a-z]{2}$/) && !locale.match(/[a-z]{2}\-[A-Z]{2}/)) {
-          continue;
+        if (!locale.match(/^[a-z]{2}$/) && !locale.match(/[a-z]{2}-[A-Z]{2}/)) {
+          continue
         }
 
-        const url = `file:///video-extracted-subtitles-${locale}.${subtitlesFormat}`;
-        const httpHeaders = { 
-          "content-type": subtitlesFormat === "vtt" ? "text/vtt" : "text/plain"
-        };
-        const body = await readFile(`${this.captureTmpFolderPath}${file}`);
-        const isEntryPoint = false;
+        const url = `file:///video-extracted-subtitles-${locale}.${subtitlesFormat}`
+        const httpHeaders = {
+          'content-type': subtitlesFormat === 'vtt' ? 'text/vtt' : 'text/plain'
+        }
+        const body = await readFile(`${this.captureTmpFolderPath}${file}`)
+        const isEntryPoint = false
 
-        this.addGeneratedExchange(url, httpHeaders, body, isEntryPoint);
-        subtitlesAvailableLocales.push(locale); // Keep track of available locales
-        subtitlesSaved = true;
+        this.addGeneratedExchange(url, httpHeaders, body, isEntryPoint)
+        subtitlesAvailableLocales.push(locale) // Keep track of available locales
+        subtitlesSaved = true
       }
-    }
-    catch(err) {
+    } catch (err) {
       // Ignore subtitles-related errors.
-      //console.log(err);
+      // console.log(err);
     }
 
     //
@@ -591,19 +578,18 @@ export class Mischief {
         subtitlesSaved,
         subtitlesAvailableLocales,
         subtitlesFormat,
-        metadataParsed,
-      });
+        metadataParsed
+      })
 
-      const url = `file:///video-extracted-summary.html`;
-      const httpHeaders = { "content-type": "text/html" };
-      const body = Buffer.from(html);
-      const isEntryPoint = true;
-      const description = `Extracted Video from: ${this.url}`;
+      const url = 'file:///video-extracted-summary.html'
+      const httpHeaders = { 'content-type': 'text/html' }
+      const body = Buffer.from(html)
+      const isEntryPoint = true
+      const description = `Extracted Video from: ${this.url}`
 
-      this.addGeneratedExchange(url, httpHeaders, body, isEntryPoint, description);
-    }
-    catch(err) {
-      throw new Error(`Error while creating exchange for file:///video-extracted-summary.html. ${err}`);
+      this.addGeneratedExchange(url, httpHeaders, body, isEntryPoint, description)
+    } catch (err) {
+      throw new Error(`Error while creating exchange for file:///video-extracted-summary.html. ${err}`)
     }
   }
 
@@ -611,67 +597,66 @@ export class Mischief {
    * Tries to generate a PDF snapshot from Playwright and add it as a generated exchange (`file:///pdf-snapshot.pdf`).
    * If `ghostscript` is available, will try to compress the resulting PDF.
    * Dimensions of the PDF are based on current document width and height.
-   * 
+   *
    * @param {object} page - Playwright "Page" object
    * @private
    */
-  async #takePdfSnapshot(page) {
-    let pdf = null;
-    let dimensions = null;
-    const tmpFilenameIn = `${this.captureTmpFolderPath}${this.id}-raw.pdf`;
+  async #takePdfSnapshot (page) {
+    let pdf = null
+    let dimensions = null
+    const tmpFilenameIn = `${this.captureTmpFolderPath}${this.id}-raw.pdf`
     const tmpFilenameOut = `${this.captureTmpFolderPath}${this.id}-compressed.pdf`
 
-    await page.emulateMedia({media: 'screen'});
+    await page.emulateMedia({ media: 'screen' })
 
     // Pull dimensions from live browser
-    dimensions = await page.evaluate(() =>  {
-      const width = Math.max(document.body.scrollWidth, window.outerWidth);
-      const height = Math.max(document.body.scrollHeight, window.outerHeight) + 50;
-      return {width, height};
-    });
+    dimensions = await page.evaluate(() => {
+      const width = Math.max(document.body.scrollWidth, window.outerWidth)
+      const height = Math.max(document.body.scrollHeight, window.outerHeight) + 50
+      return { width, height }
+    })
 
     // Generate PDF
     pdf = await page.pdf({
       printBackground: true,
       width: dimensions.width,
       height: dimensions.height
-    });
+    })
 
     // Try to apply compression if Ghostscript is available
     try {
-      await writeFile(tmpFilenameIn, pdf);
+      await writeFile(tmpFilenameIn, pdf)
 
       await exec([
-        "gs",
-        "-sDEVICE=pdfwrite",
-        "-dNOPAUSE",
-        "-dBATCH",
-        "-dJPEGQ=90",
-        "-r150",
+        'gs',
+        '-sDEVICE=pdfwrite',
+        '-dNOPAUSE',
+        '-dBATCH',
+        '-dJPEGQ=90',
+        '-r150',
         `-sOutputFile=${tmpFilenameOut}`,
-        `${tmpFilenameIn}`,
-      ].join(' '));
+        `${tmpFilenameIn}`
+      ].join(' '))
 
-      pdf = await readFile(tmpFilenameOut);
+      pdf = await readFile(tmpFilenameOut)
+    } catch (err) {
+      this.log.warn('gs command (Ghostscript) is not available or failed. The PDF Snapshot will be stored uncompressed.')
+      this.log.trace(err)
     }
-    catch(err) {
-      this.log.warn("gs command (Ghostscript) is not available or failed. The PDF Snapshot will be stored uncompressed.");
-      this.log.trace(err);
-    }
 
-    const url = "file:///pdf-snapshot.pdf";
-    const httpHeaders = {"content-type": "application/pdf"};
-    const body = pdf;
-    const isEntryPoint = true;
-    const description = `Capture Time PDF Snapshot of ${this.url}`;
+    const url = 'file:///pdf-snapshot.pdf'
+    const httpHeaders = { 'content-type': 'application/pdf' }
+    const body = pdf
+    const isEntryPoint = true
+    const description = `Capture Time PDF Snapshot of ${this.url}`
 
-    this.addGeneratedExchange(url, httpHeaders, body, isEntryPoint, description);
+    this.addGeneratedExchange(url, httpHeaders, body, isEntryPoint, description)
   }
 
   /**
    * Populates `this.provenanceInfo`, which is then used to generate a `file:///provenance-summary.html` exchange and entry point.
    * That property is also be used by `mischiefToWacz()` to populate the `extras` field of `datapackage.json`.
-   * 
+   *
    * Provenance info collected:
    * - Capture client IP, resolved using the endpoint provided in `MischiefOptions.publicIpResolverEndpoint`.
    * - Operating system details (type, name, major version, CPU architecture)
@@ -681,25 +666,24 @@ export class Mischief {
    * @param {object} page - Playwright "Page" object
    * @private
    */
-  async #captureProvenanceInfo(page) {
-    let captureIp = "UNKNOWN";
-    const osInfo = await getOSInfo();
-    const userAgent = await page.evaluate(() => window.navigator.userAgent); // Source user agent from the browser in case it was altered during capture
+  async #captureProvenanceInfo (page) {
+    let captureIp = 'UNKNOWN'
+    const osInfo = await getOSInfo()
+    const userAgent = await page.evaluate(() => window.navigator.userAgent) // Source user agent from the browser in case it was altered during capture
 
     // Grab public IP address
     try {
-      const response = await fetch(this.options.publicIpResolverEndpoint);
-      const ip = await response.text();
+      const response = await fetch(this.options.publicIpResolverEndpoint)
+      const ip = await response.text()
 
       if (!ipAddressValidator.isIPAddress(ip)) {
-        throw new Error(`${ip} is not a valid IP address.`);
+        throw new Error(`${ip} is not a valid IP address.`)
       }
 
-      captureIp = ip;
-    }
-    catch(err) {
-      this.log.warn("Public IP address could not be found.");
-      this.log.trace(err);
+      captureIp = ip
+    } catch (err) {
+      this.log.warn('Public IP address could not be found.')
+      this.log.trace(err)
     }
 
     // Gather provenance info
@@ -720,56 +704,55 @@ export class Mischief {
       const html = nunjucks.render(`${ASSETS_DIR}provenance-summary.njk`, {
         ...this.provenanceInfo,
         date: this.startedAt.toISOString(),
-        url: this.url,
-      });
+        url: this.url
+      })
 
-      const url = `file:///provenance-summary.html`;
-      const httpHeaders = { "content-type": "text/html" };
-      const body = Buffer.from(html);
-      const isEntryPoint = true;
-      const description = `Provenance Summary`;
+      const url = 'file:///provenance-summary.html'
+      const httpHeaders = { 'content-type': 'text/html' }
+      const body = Buffer.from(html)
+      const isEntryPoint = true
+      const description = 'Provenance Summary'
 
-      this.addGeneratedExchange(url, httpHeaders, body, isEntryPoint, description);
-    }
-    catch(err) {
-      throw new Error(`Error while creating exchange for file:///provenance-summary.html. ${err}`);
+      this.addGeneratedExchange(url, httpHeaders, body, isEntryPoint, description)
+    } catch (err) {
+      throw new Error(`Error while creating exchange for file:///provenance-summary.html. ${err}`)
     }
   }
 
   /**
    * Generates a MischiefGeneratedExchange for generated content and adds it to `exchanges` unless time limit was reached.
-   * @param {string} url 
-   * @param {object} httpHeaders 
-   * @param {Buffer} body 
+   * @param {string} url
+   * @param {object} httpHeaders
+   * @param {Buffer} body
    * @param {boolean} isEntryPoint
-   * @param {string} description 
-   * @returns 
+   * @param {string} description
+   * @returns
    */
-  async addGeneratedExchange(url, httpHeaders, body, isEntryPoint = false, description = "") {
-    const remainingSpace = this.options.maxSize - this.intercepter.byteLength;
+  async addGeneratedExchange (url, httpHeaders, body, isEntryPoint = false, description = '') {
+    const remainingSpace = this.options.maxSize - this.intercepter.byteLength
 
-    if (this.state != Mischief.states.CAPTURE ||
+    if (this.state !== Mischief.states.CAPTURE ||
         body.byteLength >= remainingSpace) {
-      this.state = Mischief.states.PARTIAL;
-      this.warn(`Generated exchange ${url} could not be saved (size limit reached).`);
-      return;
+      this.state = Mischief.states.PARTIAL
+      this.warn(`Generated exchange ${url} could not be saved (size limit reached).`)
+      return
     }
 
     this.exchanges.push(
       new MischiefGeneratedExchange({
-        description: description,
+        description,
         isEntryPoint: Boolean(isEntryPoint),
         response: {
-          url: url,
+          url,
           headers: httpHeaders,
           versionMajor: 1,
           versionMinor: 1,
           statusCode: 200,
-          statusMessage: "OK",
-          body: body,
-        },
+          statusMessage: 'OK',
+          body
+        }
       })
-    );
+    )
   }
 
   /**
@@ -777,30 +760,29 @@ export class Mischief {
    * This function throws if:
    * - `url` is not a valid url
    * - `url` is not an http / https url
-   * 
-   * @param {string} url 
+   *
+   * @param {string} url
    */
-  filterUrl(url) {
+  filterUrl (url) {
     try {
-      const filteredUrl = new URL(url); // Will throw if not a valid url
+      const filteredUrl = new URL(url) // Will throw if not a valid url
 
-      if (filteredUrl.protocol !== "https:" && filteredUrl.protocol !== "http:") {
-        throw new Error("Invalid protocol.");
+      if (filteredUrl.protocol !== 'https:' && filteredUrl.protocol !== 'http:') {
+        throw new Error('Invalid protocol.')
       }
-      
-      return filteredUrl.href;
-    }
-    catch(err) {
-      throw new Error(`Invalid url provided.\n${err}`);
+
+      return filteredUrl.href
+    } catch (err) {
+      throw new Error(`Invalid url provided.\n${err}`)
     }
   }
-  
+
   /**
    * (Shortcut) Export this Mischief capture to WARC.
    * @returns {Promise<ArrayBuffer>}
    */
-  async toWarc() {
-    return await exporters.mischiefToWarc(this);
+  async toWarc () {
+    return await exporters.mischiefToWarc(this)
   }
 
   /**
@@ -808,11 +790,11 @@ export class Mischief {
    * @param {boolean} [includeRaw=true] - Include a copy of RAW Http exchanges to the wacz (under `/raw`)?
    * @returns {Promise<ArrayBuffer>}
    */
-  async toWacz(includeRaw=true) {
-    return await exporters.mischiefToWacz(this, includeRaw);
+  async toWacz (includeRaw = true) {
+    return await exporters.mischiefToWacz(this, includeRaw)
   }
 
-  static async fromWacz(zipPath) {
-    return await importers.waczToMischief(zipPath);
+  static async fromWacz (zipPath) {
+    return await importers.waczToMischief(zipPath)
   }
 }

--- a/MischiefOptions.js
+++ b/MischiefOptions.js
@@ -4,17 +4,17 @@
  * @author The Harvard Library Innovation Lab
  * @license MIT
  */
-import path from "path";
-import { statSync } from "fs"; 
-// Note: used `statSync` instead of `stat` from `fs/promises` here for convenience. 
+import path from 'path'
+import { statSync } from 'fs'
+// Note: used `statSync` instead of `stat` from `fs/promises` here for convenience.
 // We're using `MischiefOptions.filterOptions()` in `Mischief()`, which cannot be async.
 
 export class MischiefOptions {
   /**
    * Available options and defaults for Mischief.
    * Unless specified otherwise at constructor level, Mischief will run with these settings.
-   * 
-   * @property {boolean} logLevel - Determines the logging level of this instance. Can be "silent", "trace", "debug", "info", "warn" or "error". Defaults to "info". See https://github.com/pimterry/loglevel for more information. 
+   *
+   * @property {boolean} logLevel - Determines the logging level of this instance. Can be "silent", "trace", "debug", "info", "warn" or "error". Defaults to "info". See https://github.com/pimterry/loglevel for more information.
    * @property {boolean} headless - Should Playwright run in headless mode? Defaults to `false`.
    * @property {string} proxyHost - What host should Playwright proxy through for capture? Defaults to `localhost`.
    * @property {number} proxyPort - What port should Playwright proxy through for capture? Defaults to 9000.
@@ -38,20 +38,20 @@ export class MischiefOptions {
    * @property {boolean} grabSecondaryResources - Should Mischief try to download img srcsets and secondary stylesheets? Defaults to `true`.
    * @property {boolean} runSiteSpecificBehaviors - Should Mischief run behaviors tailored to specific sites (ex: Twitter) in an attempt to better grab the page? Defaults to `true`.
    * @property {string} intercepter - Network interception method to be used. Available at the moment: "MischiefProxy".
-   * @property {string} userAgentSuffix - String to append to the user agent. Defaults to an empty string. 
+   * @property {string} userAgentSuffix - String to append to the user agent. Defaults to an empty string.
    * @property {boolean} provenanceSummary - If `true`, information about the capture process (public IP address, User Agent, software version ...) will be gathered and summarized under `file:///provenance-summary.html`. WACZ exports will also hold that information at `datapackage.json` level, under `extras`. Defaults to `true`.
    * @property {string} publicIpResolverEndpoint - URL to be used to retrieve the client's public IP address for `provenanceSummary`. Endpoint requirements: must simply return a IPv4 or IPv6 address as text. Defaults to "https://myip.lil.tools".
    * @property {string} tmpFolderPath - Path to the temporary folder Mischief uses. Defaults to `./tmp`.
    */
   static defaults = {
-    logLevel: "info",
+    logLevel: 'info',
     headless: true,
-    proxyHost: "localhost",
+    proxyHost: 'localhost',
     proxyPort: 9000,
     proxyVerbose: false,
     totalTimeout: 2 * 60 * 1000,
     loadTimeout: 30 * 1000,
-    networkIdleTimeout: 30 * 1000, 
+    networkIdleTimeout: 30 * 1000,
     behaviorsTimeout: 60 * 1000,
     keepPartialResponses: true,
     maxSize: 200 * 1024 * 1024,
@@ -67,59 +67,58 @@ export class MischiefOptions {
     autoPlayMedia: true,
     grabSecondaryResources: true,
     runSiteSpecificBehaviors: true,
-    intercepter: "MischiefProxy",
-    userAgentSuffix: "",
+    intercepter: 'MischiefProxy',
+    userAgentSuffix: '',
     provenanceSummary: true,
-    publicIpResolverEndpoint: "https://myip.lil.tools",
-    tmpFolderPath: `${process.env.PWD}/tmp/`,
-  };
+    publicIpResolverEndpoint: 'https://myip.lil.tools',
+    tmpFolderPath: `${process.env.PWD}/tmp/`
+  }
 
   /**
    * Filters an options object by comparing it with `MischiefOptions`.
    * Will use defaults for missing properties.
-   * 
-   * @param {object} newOptions 
+   *
+   * @param {object} newOptions
    */
-  static filterOptions(newOptions) {
-    const options = {};
-    const defaults = MischiefOptions.defaults;
+  static filterOptions (newOptions) {
+    const options = {}
+    const defaults = MischiefOptions.defaults
 
     // Create new option object from `newOptions` and `defaults`:
     // - Only pull entries from `newOptions` that are defined in `defaults`
     // - Apply basic type casting based on type of defaults
     for (const key of Object.keys(defaults)) {
-      options[key] = key in newOptions ? newOptions[key] : defaults[key];
+      options[key] = key in newOptions ? newOptions[key] : defaults[key]
 
       switch (typeof defaults[key]) {
-        case "boolean":
-          options[key] = Boolean(options[key]);
-        break;
+        case 'boolean':
+          options[key] = Boolean(options[key])
+          break
 
-        case "number":
-          options[key] = Number(options[key]);
-        break;
+        case 'number':
+          options[key] = Number(options[key])
+          break
 
-        case "string":
-          options[key] = String(options[key]);
-        break;
+        case 'string':
+          options[key] = String(options[key])
+          break
       }
     }
 
     // Check for invalid combinations
     if (options.pdfSnapshot && !options.headless) {
-      throw new Error(`"pdfSnapshot" option is only available in "headless" mode. Both options need to be "true".`);
+      throw new Error('"pdfSnapshot" option is only available in "headless" mode. Both options need to be "true".')
     }
 
     // Check that paths are valid
     if (!statSync(options.ytDlpPath).isFile()) {
-      throw new Error(`"ytDlpPath" must be a path to a file.`);
+      throw new Error('"ytDlpPath" must be a path to a file.')
     }
 
     if (options.tmpFolderPath !== path.normalize(options.tmpFolderPath)) {
-      throw new Error(`"tmpFolderPath" must be a path to a directory.`);
+      throw new Error('"tmpFolderPath" must be a path to a directory.')
     }
 
-    return options;
+    return options
   }
-
 }

--- a/constants.js
+++ b/constants.js
@@ -1,16 +1,16 @@
-import chalk from "chalk";
+import chalk from 'chalk'
 
 export default {
-  SOFTWARE: "Mischief @ Harvard Library Innovation Lab",
-  VERSION: "v0.0.1 DEV",
-  WARC_VERSION: "1.1",
-  WACZ_VERSION: "1.1.1",
+  SOFTWARE: 'Mischief @ Harvard Library Innovation Lab',
+  VERSION: 'v0.0.1 DEV',
+  WARC_VERSION: '1.1',
+  WACZ_VERSION: '1.1.1',
   LOGGING_COLORS: {
     DEFAULT: chalk.gray,
     TRACE: chalk.magenta,
     DEBUG: chalk.cyan,
     INFO: chalk.blue,
     WARN: chalk.yellow,
-    ERROR: chalk.red,
-  },
+    ERROR: chalk.red
+  }
 }

--- a/example.js
+++ b/example.js
@@ -1,63 +1,58 @@
 // [!] Example file -- to be deleted at earliest convenience.
-import { mkdir, writeFile } from "fs/promises";
-import { Mischief } from "./Mischief.js";
-import * as exporters from "./exporters/index.js";
+import { mkdir, writeFile } from 'fs/promises'
+import { Mischief } from './Mischief.js'
 
 const toCapture = [
-  {name: "google", url: "https://google.com"},
-  {name: "chrome-update", url: "http://update.googleapis.com/service/update2/json?cup2key=12:EhHNMQsbmQEJvI_P7gxZrdMKErBWF-wj-U6U8Mi83co&cup2hreq=1338f1651449d867f560f6fd72886fa074753bf76320d7864159e993fc33527b"},
-  {name: "lil", url: "https://lil.law.harvard.edu"},
-  {name: "example-http", url: "http://example.com"},
-  {name: "example-https", url: "https://example.com"},
-  {name: "df", url: "https://daringfireball.net"},
-  {name: "nyt", url: "https://www.nytimes.com"},
-  {name: "present-studio", url: "https://www.presentstudio.co/"},
-  {name: "partytronic", url: "https://partytronic.com/"},
-  {name: "cnn", url: "https://www.cnn.com/2022/08/23/tech/twitter-foreign-intel-problem/index.html"},
-  {name: "youtube-stream", url: "https://www.youtube.com/watch?v=jfKfPfyJRdk"},
-  {name: "twitter-profile", url: "https://twitter.com/macargnelutti"},
-  {name: "twitter-video", url: "https://twitter.com/dog_rates/status/1298052245209006086?s=20"},
-  {name: "youtube-video", url: "https://www.youtube.com/watch?v=zVz1SAtdw8A"},
-  {name: "cern", url: "http://info.cern.ch/hypertext/WWW/TheProject.html"},
-  {name: "sumo", url: "https://www.sumo.or.jp/EnSumoDataRikishi/profile/3761"},
-  {name: "covid-uk", url: "https://www.gov.uk/coronavirus"},
-  {name: "facebook-post", url: "https://www.facebook.com/1074538035934151/posts/3646788408709088"},
-  {name: "tiktok", url: "https://www.tiktok.com/@wbznewsradio/video/7110266333144583466"},
-  {name: "instagram-video", url: "https://www.instagram.com/reel/CguYHRlAKVX/"}
-];
+  { name: 'google', url: 'https://google.com' },
+  { name: 'chrome-update', url: 'http://update.googleapis.com/service/update2/json?cup2key=12:EhHNMQsbmQEJvI_P7gxZrdMKErBWF-wj-U6U8Mi83co&cup2hreq=1338f1651449d867f560f6fd72886fa074753bf76320d7864159e993fc33527b' },
+  { name: 'lil', url: 'https://lil.law.harvard.edu' },
+  { name: 'example-http', url: 'http://example.com' },
+  { name: 'example-https', url: 'https://example.com' },
+  { name: 'df', url: 'https://daringfireball.net' },
+  { name: 'nyt', url: 'https://www.nytimes.com' },
+  { name: 'present-studio', url: 'https://www.presentstudio.co/' },
+  { name: 'partytronic', url: 'https://partytronic.com/' },
+  { name: 'cnn', url: 'https://www.cnn.com/2022/08/23/tech/twitter-foreign-intel-problem/index.html' },
+  { name: 'youtube-stream', url: 'https://www.youtube.com/watch?v=jfKfPfyJRdk' },
+  { name: 'twitter-profile', url: 'https://twitter.com/macargnelutti' },
+  { name: 'twitter-video', url: 'https://twitter.com/dog_rates/status/1298052245209006086?s=20' },
+  { name: 'youtube-video', url: 'https://www.youtube.com/watch?v=zVz1SAtdw8A' },
+  { name: 'cern', url: 'http://info.cern.ch/hypertext/WWW/TheProject.html' },
+  { name: 'sumo', url: 'https://www.sumo.or.jp/EnSumoDataRikishi/profile/3761' },
+  { name: 'covid-uk', url: 'https://www.gov.uk/coronavirus' },
+  { name: 'facebook-post', url: 'https://www.facebook.com/1074538035934151/posts/3646788408709088' },
+  { name: 'tiktok', url: 'https://www.tiktok.com/@wbznewsradio/video/7110266333144583466' },
+  { name: 'instagram-video', url: 'https://www.instagram.com/reel/CguYHRlAKVX/' }
+]
 
-const path = "./examples/";
+const path = './examples/'
 
 try {
-  await mkdir(path);
-}
-catch(_err) {
-}
+  await mkdir(path)
+} catch (_err) { }
 
 for (const entry of toCapture) {
-  const {name, url} = entry;
+  const { name, url } = entry
 
-  const myCapture = new Mischief(url);
-  await myCapture.capture();
+  const myCapture = new Mischief(url)
+  await myCapture.capture()
 
-  for (const format of ["warc", "wacz"]) {
-    let data = null;
-    const filename = `${path}${name}.${format}`;
+  for (const format of ['warc', 'wacz']) {
+    let data = null
+    const filename = `${path}${name}.${format}`
 
-    switch(format) {
-      case "wacz":
-        data = await myCapture.toWacz();
-        break;
-  
-      case "warc":
+    switch (format) {
+      case 'wacz':
+        data = await myCapture.toWacz()
+        break
+
+      case 'warc':
       default:
-        data = await myCapture.toWarc();
-      break;
+        data = await myCapture.toWarc()
+        break
     }
 
-    await writeFile(filename, Buffer.from(data));
-    console.log(`💾 Saved ${url} as ${filename}`);
+    await writeFile(filename, Buffer.from(data))
+    console.log(`💾 Saved ${url} as ${filename}`)
   }
-
-
 }

--- a/exchanges/MischiefExchange.js
+++ b/exchanges/MischiefExchange.js
@@ -10,48 +10,48 @@
  * Represents an HTTP exchange captured by Mischief, irrespective of how it was captured.
  * To be specialized by interception type (i.e: MischiefProxyExchange).
  */
-import { v4 as uuidv4 } from "uuid";
+import { v4 as uuidv4 } from 'uuid'
 
 export class MischiefExchange {
   /** @type {?string} */
-  id = uuidv4();
+  id = uuidv4()
 
   /** @type {Date} */
-  date = new Date();
+  date = new Date()
 
   /** @type {boolean} */
-  isEntryPoint = false;
+  isEntryPoint = false
 
   /** @type {?string} */
-  connectionId;
+  connectionId
 
   /** @type {object} */
-  _request;
+  _request
 
-  set request(val) {
-    this._request = val;
+  set request (val) {
+    this._request = val
   }
 
-  get request() {
-    return this._request;
+  get request () {
+    return this._request
   }
 
   /** @type {?object} */
-  _response;
+  _response
 
-  set response(val) {
-    this._response = val;
+  set response (val) {
+    this._response = val
   }
 
-  get response() {
-    return this._response;
+  get response () {
+    return this._response
   }
 
-  constructor(props = {}) {
+  constructor (props = {}) {
     // Only accept props that reflect a defined property of `this`
     for (const [key, value] of Object.entries(props)) {
       if (key in this) {
-        this[key] = value;
+        this[key] = value
       }
     }
   }

--- a/exchanges/MischiefGeneratedExchange.js
+++ b/exchanges/MischiefGeneratedExchange.js
@@ -3,26 +3,24 @@
  * @module exchanges.MischiefGeneratedExchange
  * @author The Harvard Library Innovation Lab
  * @license MIT
- * @description 
+ * @description
 */
-import { MischiefExchange } from "./MischiefExchange.js";
+import { MischiefExchange } from './MischiefExchange.js'
 
 export class MischiefGeneratedExchange extends MischiefExchange {
-
   /** @type {?string} */
-  description;
+  description
 
   /**
    * @param {object} props - Object containing any of the properties of `this`.
    */
-  constructor(props = {}) {
-    super(props);
-    
+  constructor (props = {}) {
+    super(props)
+
     for (const [key, value] of Object.entries(props)) {
       if (key in this) {
-        this[key] = value;
+        this[key] = value
       }
     }
   }
-
 }

--- a/exchanges/MischiefProxyExchange.js
+++ b/exchanges/MischiefProxyExchange.js
@@ -3,97 +3,96 @@
  * @module exchanges.MischiefProxyExchange
  * @author The Harvard Library Innovation Lab
  * @license MIT
- * @description 
+ * @description
 */
-import { bodyStartIndex } from "../parsers/MischiefHTTPParser.js";
+import { bodyStartIndex } from '../parsers/MischiefHTTPParser.js'
 
-import { MischiefExchange } from "./MischiefExchange.js";
-import { MischiefHTTPParser } from "../parsers/index.js";
+import { MischiefExchange } from './MischiefExchange.js'
+import { MischiefHTTPParser } from '../parsers/index.js'
 
 /**
  * Represents an HTTP exchange captured via MischiefProxy.
  */
 export class MischiefProxyExchange extends MischiefExchange {
+  /** @type {?Buffer} */
+  _requestRaw
+
+  get requestRaw () {
+    return this._requestRaw
+  }
+
+  set requestRaw (val) {
+    this._request = null
+    this._requestRaw = val
+  }
+
+  get requestRawHeaders () {
+    return this.requestRaw.subarray(0, bodyStartIndex(this.requestRaw))
+  }
+
+  get requestRawBody () {
+    return this.requestRaw.subarray(bodyStartIndex(this.requestRaw))
+  }
 
   /** @type {?Buffer} */
-  _requestRaw;
+  _responseRaw
 
-  get requestRaw() {
-    return this._requestRaw;
+  get responseRaw () {
+    return this._responseRaw
   }
 
-  set requestRaw(val) {
-    this._request = null;
-    this._requestRaw = val;
+  set responseRaw (val) {
+    this._response = null
+    this._responseRaw = val
   }
 
-  get requestRawHeaders() {
-    return this.requestRaw.subarray(0, bodyStartIndex(this.requestRaw));
+  get responseRawHeaders () {
+    return this.responseRaw.subarray(0, bodyStartIndex(this.responseRaw))
   }
 
-  get requestRawBody() {
-    return this.requestRaw.subarray(bodyStartIndex(this.requestRaw));
+  get responseRawBody () {
+    return this.responseRaw.subarray(bodyStartIndex(this.responseRaw))
   }
 
-  /** @type {?Buffer} */
-  _responseRaw;
-
-  get responseRaw() {
-    return this._responseRaw;
-  }
-
-  set responseRaw(val) {
-    this._response = null;
-    this._responseRaw = val;
-  }
-
-  get responseRawHeaders() {
-    return this.responseRaw.subarray(0, bodyStartIndex(this.responseRaw));
-  }
-
-  get responseRawBody() {
-    return this.responseRaw.subarray(bodyStartIndex(this.responseRaw));
-  }
-
-  get request() {
+  get request () {
     if (!this._request && this.requestRaw) {
-      this._request = MischiefHTTPParser.parseRequest(this.requestRaw);
+      this._request = MischiefHTTPParser.parseRequest(this.requestRaw)
 
-      if(this._request.url[0] == "/"){
-        this._request.url = `https://${this._request.headers[1]}${this._request.url}`;
+      if (this._request.url[0] === '/') {
+        this._request.url = `https://${this._request.headers[1]}${this._request.url}`
       }
 
-      this._request.headers = MischiefHTTPParser.headersToMap(this._request.headers);
+      this._request.headers = MischiefHTTPParser.headersToMap(this._request.headers)
     }
-    return this._request;
+    return this._request
   }
 
-  set request(val) {
-    this._request = val;
+  set request (val) {
+    this._request = val
   }
 
-  get response() {
+  get response () {
     if (!this._response && this.responseRaw) {
-      this._response = MischiefHTTPParser.parseResponse(this.responseRaw);
-      this._response.headers = MischiefHTTPParser.headersToMap(this._response.headers);
+      this._response = MischiefHTTPParser.parseResponse(this.responseRaw)
+      this._response.headers = MischiefHTTPParser.headersToMap(this._response.headers)
       this._response.url = this.request.url
     }
-    return this._response;
+    return this._response
   }
 
-  set response(val) {
-    this._response = val;
+  set response (val) {
+    this._response = val
   }
 
   /**
    * @param {object} props - Object containing any of the properties of `this`.
    */
-  constructor(props = {}) {
-    super(props);
+  constructor (props = {}) {
+    super(props)
 
     for (const [key, value] of Object.entries(props)) {
       if (key in this) {
-        this[key] = value;
+        this[key] = value
       }
     }
   }

--- a/exchanges/index.js
+++ b/exchanges/index.js
@@ -6,12 +6,12 @@
  * @description Entry point for the exchanges module.
  */
 
-import { MischiefExchange } from "./MischiefExchange.js";
-import { MischiefProxyExchange } from "./MischiefProxyExchange.js";
-import { MischiefGeneratedExchange } from "./MischiefGeneratedExchange.js"
+import { MischiefExchange } from './MischiefExchange.js'
+import { MischiefProxyExchange } from './MischiefProxyExchange.js'
+import { MischiefGeneratedExchange } from './MischiefGeneratedExchange.js'
 
 export {
   MischiefExchange,
   MischiefProxyExchange,
   MischiefGeneratedExchange
-};
+}

--- a/exporters/index.js
+++ b/exporters/index.js
@@ -5,6 +5,6 @@
  * @license MIT
  * @description Entry point for the exporters module. Functions in this module are meant to be used to convert a Mischief instance into an archive format (i.e: WARC, WBN).
  */
-import { mischiefToWarc } from "./mischiefToWarc.js";
-import { mischiefToWacz } from "./mischiefToWacz.js";
-export { mischiefToWarc, mischiefToWacz };
+import { mischiefToWarc } from './mischiefToWarc.js'
+import { mischiefToWacz } from './mischiefToWacz.js'
+export { mischiefToWarc, mischiefToWacz }

--- a/exporters/mischiefToWacz.js
+++ b/exporters/mischiefToWacz.js
@@ -5,11 +5,11 @@
  * @license MIT
  * @description Mischief to WACZ exporter.
  */
-import { Readable } from "stream";
+import { Readable } from 'stream'
 
-import { Mischief } from "../Mischief.js";
-import { WACZ, mischiefExchangeToPageLine, hash } from "../utils/WACZ.js";
-import { WARCParser } from "warcio";
+import { Mischief } from '../Mischief.js'
+import { WACZ, mischiefExchangeToPageLine, hash } from '../utils/WACZ.js'
+import { WARCParser } from 'warcio'
 
 /**
  * Mischief capture to WACZ converter.
@@ -21,50 +21,49 @@ import { WARCParser } from "warcio";
  * @param {boolean} includeRaw - If `true`, includes the raw http exchanges in the WACZ.
  * @returns {Promise<ArrayBuffer>}
  */
-export async function mischiefToWacz(capture, includeRaw = false) {
-  const validStates = [Mischief.states.PARTIAL, Mischief.states.COMPLETE];
+export async function mischiefToWacz (capture, includeRaw = false) {
+  const validStates = [Mischief.states.PARTIAL, Mischief.states.COMPLETE]
 
   if (!(capture instanceof Mischief) || !validStates.includes(capture.state)) {
-    throw new Error("`capture` must be a partial or complete Mischief object.");
+    throw new Error('`capture` must be a partial or complete Mischief object.')
   }
 
-  const wacz = new WACZ();
+  const wacz = new WACZ()
 
   // Append WARC
-  const warc = Buffer.from(await capture.toWarc());
-  wacz.files['archive/data.warc'] = warc;
+  const warc = Buffer.from(await capture.toWarc())
+  wacz.files['archive/data.warc'] = warc
 
   // Append extra `datapackage.json` info:
   if (capture.options.provenanceSummary && capture.provenanceInfo) {
-    wacz.datapackageExtras = {"provenanceInfo": capture.provenanceInfo};
+    wacz.datapackageExtras = { provenanceInfo: capture.provenanceInfo }
   }
 
   // Append raw exchanges
   if (includeRaw) {
-    const parser = new WARCParser(Readable.from(warc));
-    const warcPayloadDigests = [];
+    const parser = new WARCParser(Readable.from(warc))
+    const warcPayloadDigests = []
     // compiles a list of payload digests to match against below
     for await (const record of parser) {
-      const digest = record.warcHeader('WARC-Payload-Digest');
-      if(digest){
-        warcPayloadDigests.push(digest);
+      const digest = record.warcHeader('WARC-Payload-Digest')
+      if (digest) {
+        warcPayloadDigests.push(digest)
       }
     }
 
     capture.exchanges.forEach((exchange) => {
       ['request', 'response'].forEach((type) => {
-        const data = exchange[`${type}Raw`];
+        const data = exchange[`${type}Raw`]
         if (data) {
-          const fpath = `raw/${type}_${exchange.date.toISOString()}_${exchange.id}`;
-          const digest = exchange[type].body.length ? hash(exchange[type].body) : null;
+          const fpath = `raw/${type}_${exchange.date.toISOString()}_${exchange.id}`
+          const digest = exchange[type].body.length ? hash(exchange[type].body) : null
           // if the WARC contains identical body data, remove it from this raw exchange
           // to avoid data bloat and add the digest to the end of the file name for later retrieval
-          if(warcPayloadDigests.includes(digest)){
+          if (warcPayloadDigests.includes(digest)) {
             // add only the headers along with trailing CRLF
             wacz.files[`${fpath}_${digest}`] = exchange[`${type}RawHeaders`]
-          }
-          else {
-            wacz.files[fpath] = data;
+          } else {
+            wacz.files[fpath] = data
           }
         }
       })
@@ -74,8 +73,8 @@ export async function mischiefToWacz(capture, includeRaw = false) {
   // Generate entry points (exchanges added to `pages.jsonl`).
   const firstExchange = capture.exchanges[0]
   wacz.pages = capture.exchanges
-                      .filter((ex) => ex === firstExchange || ex.isEntryPoint)
-                      .map(mischiefExchangeToPageLine);
+    .filter((ex) => ex === firstExchange || ex.isEntryPoint)
+    .map(mischiefExchangeToPageLine)
 
-  return await wacz.finalize();
+  return await wacz.finalize()
 }

--- a/exporters/mischiefToWarc.js
+++ b/exporters/mischiefToWarc.js
@@ -6,68 +6,68 @@
  * @description Mischief to WARC exporter.
  */
 
-import crypto from "crypto"; // warcio needs the crypto utils suite but does not import it.
-global.crypto = crypto;
+import crypto from 'crypto'
+import { Blob } from 'buffer'
 
-import { WARCRecord, WARCSerializer } from "warcio";
+import { WARCRecord, WARCSerializer } from 'warcio'
 
-import CONSTANTS from "../constants.js";
-import { Mischief } from "../Mischief.js";;
+import CONSTANTS from '../constants.js'
+import { Mischief } from '../Mischief.js' // warcio needs the crypto utils suite but does not import it.
+global.crypto = crypto
 
 /**
  * Mischief capture to WARC converter.
- * 
+ *
  * Note:
- * - Logs are added to capture object via `Mischief.log`. 
- * 
+ * - Logs are added to capture object via `Mischief.log`.
+ *
  * @param {Mischief} capture
  * @returns {Promise<ArrayBuffer>}
  */
-export async function mischiefToWarc(capture) {
-  let serializedInfo = null;
-  const serializedRecords = [];
-  const validStates = [Mischief.states.PARTIAL, Mischief.states.COMPLETE];
+export async function mischiefToWarc (capture) {
+  let serializedInfo = null
+  const serializedRecords = []
+  const validStates = [Mischief.states.PARTIAL, Mischief.states.COMPLETE]
 
   // Check capture state
   if (!(capture instanceof Mischief) || !validStates.includes(capture.state)) {
-    throw new Error("`capture` must be a partial or complete Mischief capture object.");
+    throw new Error('`capture` must be a partial or complete Mischief capture object.')
   }
 
   //
   // Prepare WARC info section
   //
   const info = WARCRecord.createWARCInfo(
-    { filename: "archive.warc", warcVersion: `WARC/${CONSTANTS.WARC_VERSION}` },
+    { filename: 'archive.warc', warcVersion: `WARC/${CONSTANTS.WARC_VERSION}` },
     { software: `${CONSTANTS.SOFTWARE} ${CONSTANTS.VERSION}` }
-  );
-  serializedInfo = await WARCSerializer.serialize(info);
-  
+  )
+  serializedInfo = await WARCSerializer.serialize(info)
+
   //
   // Prepare WARC records section
   //
   for (const exchange of capture.exchanges) {
     // Ignore loose requests
     if (!exchange.response) {
-      continue;
+      continue
     }
 
     for (const type of ['request', 'response']) {
-
       // Ignore empty records
       if (!exchange[type]) {
-        continue;
+        continue
       }
 
       try {
-        async function* content() {
-          yield (exchange[`${type}RawBody`] || exchange[type].body);
+        async function * content () {
+          yield (exchange[`${type}RawBody`] || exchange[type].body)
         }
 
         const warcHeaders = {
-          "exchange-id": exchange.id
+          'exchange-id': exchange.id
         }
 
-        if(exchange.description) {
+        if (exchange.description) {
           warcHeaders.description = exchange.description
         }
 
@@ -75,7 +75,7 @@ export async function mischiefToWarc(capture) {
           {
             url: exchange[type].url,
             date: exchange.date.toISOString(),
-            type: type,
+            type,
             warcVersion: `WARC/${CONSTANTS.WARC_VERSION}`,
             statusline: prepareExchangeStatusLine(exchange, type),
             httpHeaders: exchange[type].headers,
@@ -83,13 +83,12 @@ export async function mischiefToWarc(capture) {
             warcHeaders
           },
           content()
-        );
+        )
 
-        serializedRecords.push(await WARCSerializer.serialize(record));
-      }
-      catch(err) {
-        capture.log.warn(`${exchange[type].url} ${type} could not be added to warc.`);
-        capture.log.trace(err);
+        serializedRecords.push(await WARCSerializer.serialize(record))
+      } catch (err) {
+        capture.log.warn(`${exchange[type].url} ${type} could not be added to warc.`)
+        capture.log.trace(err)
       }
     }
   }
@@ -97,36 +96,36 @@ export async function mischiefToWarc(capture) {
   //
   // Combine output and return as ArrayBuffer
   //
-  return new Blob([serializedInfo, ...serializedRecords]).arrayBuffer();
+  return new Blob([serializedInfo, ...serializedRecords]).arrayBuffer()
 }
 
 /**
  * Prepares an HTTP status line string for a given MischiefExchange.
- * 
+ *
  * Warcio expects the method to be prepended to the request statusLine.
  * Reference:
  * - https://github.com/webrecorder/pywb/pull/636#issue-869181282
  * - https://github.com/webrecorder/warcio.js/blob/d5dcaec38ffb0a905fd7151273302c5f478fe5d9/src/statusandheaders.js#L69-L74
  * - https://github.com/webrecorder/warcio.js/blob/fdb68450e2e011df24129bac19691073ab6b2417/test/testSerializer.js#L212
- * 
- * @param {MischiefExchange} exchange 
- * @param {string} [type="response"] 
+ *
+ * @param {MischiefExchange} exchange
+ * @param {string} [type="response"]
  * @returns {string}
  */
-function prepareExchangeStatusLine(exchange, type = "response") {
-  let statusLine = ``;
-  const reqOrResp = exchange[type];
+function prepareExchangeStatusLine (exchange, type = 'response') {
+  let statusLine = ''
+  const reqOrResp = exchange[type]
 
-  switch(type) {
-    case "request":
-      statusLine = `${reqOrResp.method} ${reqOrResp.url} HTTP/${reqOrResp.versionMajor}.${reqOrResp.versionMinor}`;
-    break;
+  switch (type) {
+    case 'request':
+      statusLine = `${reqOrResp.method} ${reqOrResp.url} HTTP/${reqOrResp.versionMajor}.${reqOrResp.versionMinor}`
+      break
 
-    case "response":
+    case 'response':
     default:
-      statusLine = `HTTP/${reqOrResp.versionMajor}.${reqOrResp.versionMinor} ${reqOrResp.statusCode} ${reqOrResp.statusMessage}`;
-    break;
+      statusLine = `HTTP/${reqOrResp.versionMajor}.${reqOrResp.versionMinor} ${reqOrResp.statusCode} ${reqOrResp.statusMessage}`
+      break
   }
 
-  return statusLine;
+  return statusLine
 }

--- a/importers/index.js
+++ b/importers/index.js
@@ -5,5 +5,5 @@
  * @license MIT
  * @description Entry point for the importers module.
  */
-import { waczToMischief } from "./waczToMischief.js";
-export { waczToMischief };
+import { waczToMischief } from './waczToMischief.js'
+export { waczToMischief }

--- a/intercepters/MischiefIntercepter.js
+++ b/intercepters/MischiefIntercepter.js
@@ -1,40 +1,39 @@
-import { Mischief } from "../Mischief.js";
+import { Mischief } from '../Mischief.js'
 
 export class MischiefIntercepter {
+  capture
 
-  capture;
+  byteLength = 0
 
-  byteLength = 0;
+  exchanges = []
 
-  exchanges = [];
-
-  constructor(capture) {
-    this.capture = capture;
-    return this;
+  constructor (capture) {
+    this.capture = capture
+    return this
   }
 
   // convenience function
-  get options() {
-    return this.capture.options;
+  get options () {
+    return this.capture.options
   }
 
-  setup(_page) {
-    throw 'method must be implemented';
+  setup (_page) {
+    throw new Error('method must be implemented')
   }
 
-  teardown() {
-    throw 'method must be implemented';
+  teardown () {
+    throw new Error('method must be implemented')
   }
 
-  get contextOptions() {
-    return {};
+  get contextOptions () {
+    return {}
   }
 
-  checkAndEnforceSizeLimit() {
-    if(this.byteLength >= this.options.maxSize && this.capture.state == Mischief.states.CAPTURE) {
-      this.capture.log.warn(`Max size ${this.options.maxSize} reached. Ending interception.`);
-      this.capture.state = Mischief.states.PARTIAL;
-      this.capture.teardown();
+  checkAndEnforceSizeLimit () {
+    if (this.byteLength >= this.options.maxSize && this.capture.state === Mischief.states.CAPTURE) {
+      this.capture.log.warn(`Max size ${this.options.maxSize} reached. Ending interception.`)
+      this.capture.state = Mischief.states.PARTIAL
+      this.capture.teardown()
     }
   }
 }

--- a/intercepters/index.js
+++ b/intercepters/index.js
@@ -5,7 +5,7 @@
  * @license MIT
  * @description Entry point for the scribes module.
  */
-import { MischiefIntercepter } from "./MischiefIntercepter.js";
-import { MischiefProxy } from "./MischiefProxy.js";
+import { MischiefIntercepter } from './MischiefIntercepter.js'
+import { MischiefProxy } from './MischiefProxy.js'
 
-export { MischiefIntercepter, MischiefProxy };
+export { MischiefIntercepter, MischiefProxy }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,8 +27,105 @@
       },
       "devDependencies": {
         "@types/node": "^18.11.0",
-        "prettier": "^2.7.1"
+        "standard": "*"
       }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
+      "integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.4.0",
+        "globals": "^13.15.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.11.7",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.7.tgz",
+      "integrity": "sha512-kBbPWzN8oVMLb0hOUYXhmxggL/1cJE6ydvjDIGi9EnAGUyA7cLVKQg+d/Dsm+KZwx2czGHrCmMVLiyg8s5JPKw==",
+      "dev": true,
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^1.2.1",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "dev": true
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "18.11.9",
@@ -40,6 +137,43 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
       "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA=="
+    },
+    "node_modules/acorn": {
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -125,6 +259,80 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/array-includes": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.6.tgz",
+      "integrity": "sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "get-intrinsic": "^1.1.3",
+        "is-string": "^1.0.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz",
+      "integrity": "sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-shim-unscopables": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.1.tgz",
+      "integrity": "sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-shim-unscopables": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.tosorted": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.1.tgz",
+      "integrity": "sha512-pZYPXPRl2PqWcsUs6LOMn+1f1532nEoPTYowBtqLwAW+W8vSVhkIGnmOX1t/UQjD6YGI0vcD2B1U7ZFGQH9jnQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-shim-unscopables": "^1.0.0",
+        "get-intrinsic": "^1.1.3"
       }
     },
     "node_modules/asap": {
@@ -214,6 +422,37 @@
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/builtins": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
+      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.0.0"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/camelcase": {
@@ -329,12 +568,63 @@
         "node": ">= 8"
       }
     },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
+    },
+    "node_modules/define-properties": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+      "dev": true,
+      "dependencies": {
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/emoji-regex": {
@@ -348,6 +638,629 @@
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-abstract": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.5.tgz",
+      "integrity": "sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "function.prototype.name": "^1.1.5",
+        "get-intrinsic": "^1.1.3",
+        "get-symbol-description": "^1.0.0",
+        "gopd": "^1.0.1",
+        "has": "^1.0.3",
+        "has-property-descriptors": "^1.0.0",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.3",
+        "is-callable": "^1.2.7",
+        "is-negative-zero": "^2.0.2",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "is-string": "^1.0.7",
+        "is-weakref": "^1.0.2",
+        "object-inspect": "^1.12.2",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.4.3",
+        "safe-regex-test": "^1.0.0",
+        "string.prototype.trimend": "^1.0.6",
+        "string.prototype.trimstart": "^1.0.6",
+        "unbox-primitive": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
+      "integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.3"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "8.29.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.29.0.tgz",
+      "integrity": "sha512-isQ4EEiyUjZFbEKvEGJKKGBwXtvXX+zJbkVKCgTuB9t/+jUBcy8avhkEwWJecI15BkRkOYmvIM5ynbhRjEkoeg==",
+      "dev": true,
+      "dependencies": {
+        "@eslint/eslintrc": "^1.3.3",
+        "@humanwhocodes/config-array": "^0.11.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.1.1",
+        "eslint-utils": "^3.0.0",
+        "eslint-visitor-keys": "^3.3.0",
+        "espree": "^9.4.0",
+        "esquery": "^1.4.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.15.0",
+        "grapheme-splitter": "^1.0.4",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-sdsl": "^4.1.4",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "regexpp": "^3.2.0",
+        "strip-ansi": "^6.0.1",
+        "strip-json-comments": "^3.1.0",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-config-standard": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.0.0.tgz",
+      "integrity": "sha512-/2ks1GKyqSOkH7JFvXJicu0iMpoojkwB+f5Du/1SC0PtBL+s8v30k9njRZ21pm2drKYm2342jFnGWzttxPmZVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "peerDependencies": {
+        "eslint": "^8.0.1",
+        "eslint-plugin-import": "^2.25.2",
+        "eslint-plugin-n": "^15.0.0",
+        "eslint-plugin-promise": "^6.0.0"
+      }
+    },
+    "node_modules/eslint-config-standard-jsx": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-11.0.0.tgz",
+      "integrity": "sha512-+1EV/R0JxEK1L0NGolAr8Iktm3Rgotx3BKwgaX+eAuSX8D952LULKtjgZD3F+e6SvibONnhLwoTi9DPxN5LvvQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "peerDependencies": {
+        "eslint": "^8.8.0",
+        "eslint-plugin-react": "^7.28.0"
+      }
+    },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
+      "integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^3.2.7",
+        "resolve": "^1.20.0"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-module-utils": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.4.tgz",
+      "integrity": "sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^3.2.7"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-es": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz",
+      "integrity": "sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==",
+      "dev": true,
+      "dependencies": {
+        "eslint-utils": "^2.0.0",
+        "regexpp": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=4.19.1"
+      }
+    },
+    "node_modules/eslint-plugin-es/node_modules/eslint-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
+    "node_modules/eslint-plugin-es/node_modules/eslint-visitor-keys": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-plugin-import": {
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
+      "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
+      "dev": true,
+      "dependencies": {
+        "array-includes": "^3.1.4",
+        "array.prototype.flat": "^1.2.5",
+        "debug": "^2.6.9",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.6",
+        "eslint-module-utils": "^2.7.3",
+        "has": "^1.0.3",
+        "is-core-module": "^2.8.1",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.1.2",
+        "object.values": "^1.1.5",
+        "resolve": "^1.22.0",
+        "tsconfig-paths": "^3.14.1"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true
+    },
+    "node_modules/eslint-plugin-n": {
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.6.0.tgz",
+      "integrity": "sha512-Hd/F7wz4Mj44Jp0H6Jtty13NcE69GNTY0rVlgTIj1XBnGGVI6UTdDrpE6vqu3AHo07bygq/N+7OH/lgz1emUJw==",
+      "dev": true,
+      "dependencies": {
+        "builtins": "^5.0.1",
+        "eslint-plugin-es": "^4.1.0",
+        "eslint-utils": "^3.0.0",
+        "ignore": "^5.1.1",
+        "is-core-module": "^2.11.0",
+        "minimatch": "^3.1.2",
+        "resolve": "^1.22.1",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-promise": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.1.1.tgz",
+      "integrity": "sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react": {
+      "version": "7.31.11",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.31.11.tgz",
+      "integrity": "sha512-TTvq5JsT5v56wPa9OYHzsrOlHzKZKjV+aLgS+55NJP/cuzdiQPC7PfYoUjMoxlffKtvijpk7vA/jmuqRb9nohw==",
+      "dev": true,
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flatmap": "^1.3.1",
+        "array.prototype.tosorted": "^1.1.1",
+        "doctrine": "^2.1.0",
+        "estraverse": "^5.3.0",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.6",
+        "object.fromentries": "^2.0.6",
+        "object.hasown": "^1.1.2",
+        "object.values": "^1.1.6",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.3",
+        "semver": "^6.3.0",
+        "string.prototype.matchall": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/resolve": {
+      "version": "2.0.0-next.4",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz",
+      "integrity": "sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.9.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "engines": {
+        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=5"
+      }
+    },
+    "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/eslint/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
+      "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.8.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/execa": {
@@ -372,6 +1285,45 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true
+    },
+    "node_modules/fastq": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.14.0.tgz",
+      "integrity": "sha512-eR2D+V9/ExcbF9ls441yIuN6TI2ED1Y2ZcA5BmMtJsOkWOFRJQ0Jt0g1UwqXJJVAb+V+umH5Dfr8oh4EVP7VVg==",
+      "dev": true,
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -384,6 +1336,25 @@
         "node": ">=8"
       }
     },
+    "node_modules/flat-cache": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "dev": true,
+      "dependencies": {
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
+      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
+      "dev": true
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -394,12 +1365,59 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.0",
+        "functions-have-names": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-os-info": {
@@ -413,6 +1431,18 @@
         "windows-release": "^5.0.1"
       }
     },
+    "node_modules/get-stdin": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
+      "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -422,6 +1452,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/getos": {
@@ -451,10 +1497,124 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "13.19.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.19.0.tgz",
+      "integrity": "sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+    },
+    "node_modules/grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+      "dev": true
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-bigints": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/hi-base32": {
       "version": "0.5.1",
@@ -493,6 +1653,40 @@
         }
       ]
     },
+    "node_modules/ignore": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.1.tgz",
+      "integrity": "sha512-d2qQLzTJ9WxQftPAuEQpSPmKqzxePjzVbpAVv62AQ64NTL+wR4JkrVqR/LqFsFEUsHDAiId52mJteHDFuDkElA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -507,10 +1701,106 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "node_modules/internal-slot": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.0",
+        "has": "^1.0.3",
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/ip-address-validator": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/ip-address-validator/-/ip-address-validator-1.0.7.tgz",
       "integrity": "sha512-PZFl2+tVajBSvQyQZIJ1Pi+wVJSpSFhr4DbLOFgP4PgvdZY/8Soe2p6/ofR+Vfw2WI3WOdtIcPycnisb3Ec4BA=="
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true
+    },
+    "node_modules/is-bigint": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "dev": true,
+      "dependencies": {
+        "has-bigints": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -518,6 +1808,82 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+      "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-stream": {
@@ -531,6 +1897,48 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-string": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -540,6 +1948,77 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "node_modules/js-sdsl": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.2.0.tgz",
+      "integrity": "sha512-dyBIzQBDkCqCu+0upx25Y2jGdbTGxE9fshMsCdK0ViOongpV+n5tXRcZY9v7CaVQ79AGS9KA1KHtojxiM7aXSQ==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true
+    },
+    "node_modules/json5": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz",
+      "integrity": "sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==",
+      "dev": true,
+      "dependencies": {
+        "array-includes": "^3.1.5",
+        "object.assign": "^4.1.3"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
     },
     "node_modules/lazystream": {
       "version": "1.0.1",
@@ -579,6 +2058,44 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/load-json-file": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
+      "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.15",
+        "parse-json": "^4.0.0",
+        "pify": "^4.0.1",
+        "strip-bom": "^3.0.0",
+        "type-fest": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/load-json-file/node_modules/type-fest": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+      "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -610,6 +2127,12 @@
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
     },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
     "node_modules/lodash.union": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
@@ -631,6 +2154,30 @@
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.8.4.tgz",
       "integrity": "sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g=="
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/macos-release": {
       "version": "3.1.0",
@@ -666,6 +2213,27 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true
     },
     "node_modules/node-stream-zip": {
       "version": "1.15.0",
@@ -722,6 +2290,112 @@
         }
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+      "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "has-symbols": "^1.0.3",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.entries": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.6.tgz",
+      "integrity": "sha512-leTPzo4Zvg3pmbQ3rDK69Rl8GQvIqMWubrkxONG9/ojtFE2rD9fjMKfSI5BxW3osRH1m6VdzmqK8oAY9aT4x5w==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.6.tgz",
+      "integrity": "sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.hasown": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.2.tgz",
+      "integrity": "sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.6.tgz",
+      "integrity": "sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -742,6 +2416,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "dev": true,
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/os-family": {
@@ -787,6 +2478,31 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+      "dev": true,
+      "dependencies": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -809,6 +2525,80 @@
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-conf": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
+      "integrity": "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^3.0.0",
+        "load-json-file": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-conf/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-conf/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-conf/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-conf/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/playwright": {
@@ -837,25 +2627,65 @@
         "node": ">=14"
       }
     },
-    "node_modules/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
       "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
     },
     "node_modules/readable-stream": {
       "version": "3.6.0",
@@ -897,6 +2727,35 @@
         "node": ">=10"
       }
     },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexpp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -909,6 +2768,80 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+    },
+    "node_modules/resolve": {
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.9.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -928,6 +2861,35 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
+      "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "is-regex": "^1.1.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/set-blocking": {
       "version": "2.0.0",
@@ -953,10 +2915,89 @@
         "node": ">=8"
       }
     },
+    "node_modules/side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
+    "node_modules/standard": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/standard/-/standard-17.0.0.tgz",
+      "integrity": "sha512-GlCM9nzbLUkr+TYR5I2WQoIah4wHA2lMauqbyPLV/oI5gJxqhHzhjl9EG2N0lr/nRqI3KCbCvm/W3smxvLaChA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "eslint": "^8.13.0",
+        "eslint-config-standard": "17.0.0",
+        "eslint-config-standard-jsx": "^11.0.0",
+        "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-n": "^15.1.0",
+        "eslint-plugin-promise": "^6.0.0",
+        "eslint-plugin-react": "^7.28.0",
+        "standard-engine": "^15.0.0"
+      },
+      "bin": {
+        "standard": "bin/cmd.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/standard-engine": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-15.0.0.tgz",
+      "integrity": "sha512-4xwUhJNo1g/L2cleysUqUv7/btn7GEbYJvmgKrQ2vd/8pkTmN8cpqAZg+BT8Z1hNeEH787iWUdOpL8fmApLtxA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "get-stdin": "^8.0.0",
+        "minimist": "^1.2.6",
+        "pkg-conf": "^3.1.0",
+        "xdg-basedir": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -979,6 +3020,53 @@
         "node": ">=8"
       }
     },
+    "node_modules/string.prototype.matchall": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.8.tgz",
+      "integrity": "sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.3",
+        "regexp.prototype.flags": "^1.4.3",
+        "side-channel": "^1.0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
+      "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
+      "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -990,12 +3078,57 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/tar-stream": {
@@ -1013,10 +3146,76 @@
         "node": ">=6"
       }
     },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true
+    },
     "node_modules/transparent-proxy": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/transparent-proxy/-/transparent-proxy-1.9.1.tgz",
       "integrity": "sha512-1Y32CDNQJrVExGpsJM4ugEHNKYwHHmZL7SZZT7CyYwnMN8upisZYqufWPSXPi5x35Y3q9LWZR2O7sqF5BSiobQ=="
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
+      "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.1",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
+        "which-boxed-primitive": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -1064,6 +3263,22 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
+      "dependencies": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
@@ -1081,6 +3296,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wrap-ansi": {
@@ -1101,10 +3325,25 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
+    "node_modules/xdg-basedir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/y18n": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
       "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/yargs": {
       "version": "15.4.1",
@@ -1139,6 +3378,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/zip-stream": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.0.tgz",
@@ -1154,6 +3405,78 @@
     }
   },
   "dependencies": {
+    "@eslint/eslintrc": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
+      "integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.4.0",
+        "globals": "^13.15.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      }
+    },
+    "@humanwhocodes/config-array": {
+      "version": "0.11.7",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.7.tgz",
+      "integrity": "sha512-kBbPWzN8oVMLb0hOUYXhmxggL/1cJE6ydvjDIGi9EnAGUyA7cLVKQg+d/Dsm+KZwx2czGHrCmMVLiyg8s5JPKw==",
+      "dev": true,
+      "requires": {
+        "@humanwhocodes/object-schema": "^1.2.1",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.5"
+      }
+    },
+    "@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true
+    },
+    "@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "dev": true
+    },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      }
+    },
+    "@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true
+    },
     "@types/node": {
       "version": "18.11.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
@@ -1164,6 +3487,31 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
       "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA=="
+    },
+    "acorn": {
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "requires": {}
+    },
+    "ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
     },
     "ansi-regex": {
       "version": "5.0.1",
@@ -1238,6 +3586,62 @@
         }
       }
     },
+    "argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "array-includes": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.6.tgz",
+      "integrity": "sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "get-intrinsic": "^1.1.3",
+        "is-string": "^1.0.7"
+      }
+    },
+    "array.prototype.flat": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz",
+      "integrity": "sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-shim-unscopables": "^1.0.0"
+      }
+    },
+    "array.prototype.flatmap": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.1.tgz",
+      "integrity": "sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-shim-unscopables": "^1.0.0"
+      }
+    },
+    "array.prototype.tosorted": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.1.tgz",
+      "integrity": "sha512-pZYPXPRl2PqWcsUs6LOMn+1f1532nEoPTYowBtqLwAW+W8vSVhkIGnmOX1t/UQjD6YGI0vcD2B1U7ZFGQH9jnQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-shim-unscopables": "^1.0.0",
+        "get-intrinsic": "^1.1.3"
+      }
+    },
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -1295,6 +3699,31 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="
+    },
+    "builtins": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
+      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
+      "dev": true,
+      "requires": {
+        "semver": "^7.0.0"
+      }
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
     },
     "camelcase": {
       "version": "5.3.1",
@@ -1379,10 +3808,44 @@
         "which": "^2.0.1"
       }
     },
+    "debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "requires": {
+        "ms": "2.1.2"
+      }
+    },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="
+    },
+    "deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+      "dev": true,
+      "requires": {
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      }
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -1396,6 +3859,447 @@
       "requires": {
         "once": "^1.4.0"
       }
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "es-abstract": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.5.tgz",
+      "integrity": "sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "function.prototype.name": "^1.1.5",
+        "get-intrinsic": "^1.1.3",
+        "get-symbol-description": "^1.0.0",
+        "gopd": "^1.0.1",
+        "has": "^1.0.3",
+        "has-property-descriptors": "^1.0.0",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.3",
+        "is-callable": "^1.2.7",
+        "is-negative-zero": "^2.0.2",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "is-string": "^1.0.7",
+        "is-weakref": "^1.0.2",
+        "object-inspect": "^1.12.2",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.4.3",
+        "safe-regex-test": "^1.0.0",
+        "string.prototype.trimend": "^1.0.6",
+        "string.prototype.trimstart": "^1.0.6",
+        "unbox-primitive": "^1.0.2"
+      }
+    },
+    "es-shim-unscopables": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
+      "integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true
+    },
+    "eslint": {
+      "version": "8.29.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.29.0.tgz",
+      "integrity": "sha512-isQ4EEiyUjZFbEKvEGJKKGBwXtvXX+zJbkVKCgTuB9t/+jUBcy8avhkEwWJecI15BkRkOYmvIM5ynbhRjEkoeg==",
+      "dev": true,
+      "requires": {
+        "@eslint/eslintrc": "^1.3.3",
+        "@humanwhocodes/config-array": "^0.11.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.1.1",
+        "eslint-utils": "^3.0.0",
+        "eslint-visitor-keys": "^3.3.0",
+        "espree": "^9.4.0",
+        "esquery": "^1.4.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.15.0",
+        "grapheme-splitter": "^1.0.4",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-sdsl": "^4.1.4",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "regexpp": "^3.2.0",
+        "strip-ansi": "^6.0.1",
+        "strip-json-comments": "^3.1.0",
+        "text-table": "^0.2.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        }
+      }
+    },
+    "eslint-config-standard": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.0.0.tgz",
+      "integrity": "sha512-/2ks1GKyqSOkH7JFvXJicu0iMpoojkwB+f5Du/1SC0PtBL+s8v30k9njRZ21pm2drKYm2342jFnGWzttxPmZVg==",
+      "dev": true,
+      "requires": {}
+    },
+    "eslint-config-standard-jsx": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-11.0.0.tgz",
+      "integrity": "sha512-+1EV/R0JxEK1L0NGolAr8Iktm3Rgotx3BKwgaX+eAuSX8D952LULKtjgZD3F+e6SvibONnhLwoTi9DPxN5LvvQ==",
+      "dev": true,
+      "requires": {}
+    },
+    "eslint-import-resolver-node": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
+      "integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
+      "dev": true,
+      "requires": {
+        "debug": "^3.2.7",
+        "resolve": "^1.20.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
+    "eslint-module-utils": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.4.tgz",
+      "integrity": "sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==",
+      "dev": true,
+      "requires": {
+        "debug": "^3.2.7"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
+    "eslint-plugin-es": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz",
+      "integrity": "sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==",
+      "dev": true,
+      "requires": {
+        "eslint-utils": "^2.0.0",
+        "regexpp": "^3.0.0"
+      },
+      "dependencies": {
+        "eslint-utils": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+          "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
+      "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.1.4",
+        "array.prototype.flat": "^1.2.5",
+        "debug": "^2.6.9",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.6",
+        "eslint-module-utils": "^2.7.3",
+        "has": "^1.0.3",
+        "is-core-module": "^2.8.1",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.1.2",
+        "object.values": "^1.1.5",
+        "resolve": "^1.22.0",
+        "tsconfig-paths": "^3.14.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-n": {
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.6.0.tgz",
+      "integrity": "sha512-Hd/F7wz4Mj44Jp0H6Jtty13NcE69GNTY0rVlgTIj1XBnGGVI6UTdDrpE6vqu3AHo07bygq/N+7OH/lgz1emUJw==",
+      "dev": true,
+      "requires": {
+        "builtins": "^5.0.1",
+        "eslint-plugin-es": "^4.1.0",
+        "eslint-utils": "^3.0.0",
+        "ignore": "^5.1.1",
+        "is-core-module": "^2.11.0",
+        "minimatch": "^3.1.2",
+        "resolve": "^1.22.1",
+        "semver": "^7.3.8"
+      }
+    },
+    "eslint-plugin-promise": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.1.1.tgz",
+      "integrity": "sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==",
+      "dev": true,
+      "requires": {}
+    },
+    "eslint-plugin-react": {
+      "version": "7.31.11",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.31.11.tgz",
+      "integrity": "sha512-TTvq5JsT5v56wPa9OYHzsrOlHzKZKjV+aLgS+55NJP/cuzdiQPC7PfYoUjMoxlffKtvijpk7vA/jmuqRb9nohw==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flatmap": "^1.3.1",
+        "array.prototype.tosorted": "^1.1.1",
+        "doctrine": "^2.1.0",
+        "estraverse": "^5.3.0",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.6",
+        "object.fromentries": "^2.0.6",
+        "object.hasown": "^1.1.2",
+        "object.values": "^1.1.6",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.3",
+        "semver": "^6.3.0",
+        "string.prototype.matchall": "^4.0.8"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "resolve": {
+          "version": "2.0.0-next.4",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz",
+          "integrity": "sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.9.0",
+            "path-parse": "^1.0.7",
+            "supports-preserve-symlinks-flag": "^1.0.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-scope": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      }
+    },
+    "eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "dev": true
+    },
+    "espree": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
+      "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.8.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.3.0"
+      }
+    },
+    "esquery": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.1.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.2.0"
+      }
+    },
+    "estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
     },
     "execa": {
       "version": "5.1.1",
@@ -1413,6 +4317,42 @@
         "strip-final-newline": "^2.0.0"
       }
     },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true
+    },
+    "fastq": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.14.0.tgz",
+      "integrity": "sha512-eR2D+V9/ExcbF9ls441yIuN6TI2ED1Y2ZcA5BmMtJsOkWOFRJQ0Jt0g1UwqXJJVAb+V+umH5Dfr8oh4EVP7VVg==",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^3.0.4"
+      }
+    },
     "find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -1421,6 +4361,22 @@
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
       }
+    },
+    "flat-cache": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "dev": true,
+      "requires": {
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
+      }
+    },
+    "flatted": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
+      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
+      "dev": true
     },
     "fs-constants": {
       "version": "1.0.0",
@@ -1432,10 +4388,45 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "function.prototype.name": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.0",
+        "functions-have-names": "^1.2.2"
+      }
+    },
+    "functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+    },
+    "get-intrinsic": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.3"
+      }
     },
     "get-os-info": {
       "version": "1.0.2",
@@ -1448,10 +4439,26 @@
         "windows-release": "^5.0.1"
       }
     },
+    "get-stdin": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
+      "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
+      "dev": true
+    },
     "get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
+    },
+    "get-symbol-description": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      }
     },
     "getos": {
       "version": "3.2.1",
@@ -1474,10 +4481,88 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.3"
+      }
+    },
+    "globals": {
+      "version": "13.19.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.19.0.tgz",
+      "integrity": "sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.20.2"
+      }
+    },
+    "gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.3"
+      }
+    },
     "graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+    },
+    "grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+      "dev": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-bigints": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
+    },
+    "has-property-descriptors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.1"
+      }
+    },
+    "has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "dev": true
+    },
+    "has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.2"
+      }
     },
     "hi-base32": {
       "version": "0.5.1",
@@ -1499,6 +4584,28 @@
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
+    "ignore": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.1.tgz",
+      "integrity": "sha512-d2qQLzTJ9WxQftPAuEQpSPmKqzxePjzVbpAVv62AQ64NTL+wR4JkrVqR/LqFsFEUsHDAiId52mJteHDFuDkElA==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -1513,20 +4620,162 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "internal-slot": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.0",
+        "has": "^1.0.3",
+        "side-channel": "^1.0.4"
+      }
+    },
     "ip-address-validator": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/ip-address-validator/-/ip-address-validator-1.0.7.tgz",
       "integrity": "sha512-PZFl2+tVajBSvQyQZIJ1Pi+wVJSpSFhr4DbLOFgP4PgvdZY/8Soe2p6/ofR+Vfw2WI3WOdtIcPycnisb3Ec4BA=="
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true
+    },
+    "is-bigint": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "dev": true,
+      "requires": {
+        "has-bigints": "^1.0.1"
+      }
+    },
+    "is-boolean-object": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true
+    },
+    "is-core-module": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "is-date-object": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
+    "is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-negative-zero": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+      "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+      "dev": true
+    },
+    "is-number-object": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true
+    },
+    "is-regex": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-shared-array-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2"
+      }
+    },
     "is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
+    },
+    "is-string": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.2"
+      }
+    },
+    "is-weakref": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2"
+      }
     },
     "isarray": {
       "version": "1.0.0",
@@ -1537,6 +4786,64 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "js-sdsl": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.2.0.tgz",
+      "integrity": "sha512-dyBIzQBDkCqCu+0upx25Y2jGdbTGxE9fshMsCdK0ViOongpV+n5tXRcZY9v7CaVQ79AGS9KA1KHtojxiM7aXSQ==",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "requires": {
+        "argparse": "^2.0.1"
+      }
+    },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true
+    },
+    "json5": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.0"
+      }
+    },
+    "jsx-ast-utils": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz",
+      "integrity": "sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.1.5",
+        "object.assign": "^4.1.3"
+      }
     },
     "lazystream": {
       "version": "1.0.1",
@@ -1575,6 +4882,37 @@
         }
       }
     },
+    "levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      }
+    },
+    "load-json-file": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
+      "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.15",
+        "parse-json": "^4.0.0",
+        "pify": "^4.0.1",
+        "strip-bom": "^3.0.0",
+        "type-fest": "^0.3.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+          "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+          "dev": true
+        }
+      }
+    },
     "locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -1603,6 +4941,12 @@
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
     },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
     "lodash.union": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
@@ -1617,6 +4961,24 @@
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.8.4.tgz",
       "integrity": "sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g=="
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
+      }
     },
     "macos-release": {
       "version": "3.1.0",
@@ -1640,6 +5002,24 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
+    },
+    "minimist": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "dev": true
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true
     },
     "node-stream-zip": {
       "version": "1.15.0",
@@ -1669,6 +5049,79 @@
         "commander": "^5.1.0"
       }
     },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true
+    },
+    "object-inspect": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
+    "object.assign": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+      "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "has-symbols": "^1.0.3",
+        "object-keys": "^1.1.1"
+      }
+    },
+    "object.entries": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.6.tgz",
+      "integrity": "sha512-leTPzo4Zvg3pmbQ3rDK69Rl8GQvIqMWubrkxONG9/ojtFE2rD9fjMKfSI5BxW3osRH1m6VdzmqK8oAY9aT4x5w==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      }
+    },
+    "object.fromentries": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.6.tgz",
+      "integrity": "sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      }
+    },
+    "object.hasown": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.2.tgz",
+      "integrity": "sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      }
+    },
+    "object.values": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.6.tgz",
+      "integrity": "sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      }
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1683,6 +5136,20 @@
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "requires": {
         "mimic-fn": "^2.1.0"
+      }
+    },
+    "optionator": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "dev": true,
+      "requires": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
       }
     },
     "os-family": {
@@ -1716,6 +5183,25 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
+    "parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      }
+    },
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -1731,6 +5217,64 @@
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
     },
+    "path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true
+    },
+    "pkg-conf": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
+      "integrity": "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==",
+      "dev": true,
+      "requires": {
+        "find-up": "^3.0.0",
+        "load-json-file": "^5.2.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+          "dev": true
+        }
+      }
+    },
     "playwright": {
       "version": "1.27.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.27.1.tgz",
@@ -1744,16 +5288,45 @@
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.27.1.tgz",
       "integrity": "sha512-9EmeXDncC2Pmp/z+teoVYlvmPWUC6ejSSYZUln7YaP89Z6lpAaiaAnqroUt/BoLo8tn7WYShcfaCh+xofZa44Q=="
     },
-    "prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+    "prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
     },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true
+    },
+    "react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
     },
     "readable-stream": {
       "version": "3.6.0",
@@ -1791,6 +5364,23 @@
         }
       }
     },
+    "regexp.prototype.flags": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
+      }
+    },
+    "regexpp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+      "dev": true
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -1801,10 +5391,71 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
+    "resolve": {
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+      "dev": true,
+      "requires": {
+        "is-core-module": "^2.9.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      }
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "requires": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "safe-regex-test": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
+      "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "is-regex": "^1.1.4"
+      }
+    },
+    "semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -1824,10 +5475,49 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
     },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      }
+    },
     "signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
+    "standard": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/standard/-/standard-17.0.0.tgz",
+      "integrity": "sha512-GlCM9nzbLUkr+TYR5I2WQoIah4wHA2lMauqbyPLV/oI5gJxqhHzhjl9EG2N0lr/nRqI3KCbCvm/W3smxvLaChA==",
+      "dev": true,
+      "requires": {
+        "eslint": "^8.13.0",
+        "eslint-config-standard": "17.0.0",
+        "eslint-config-standard-jsx": "^11.0.0",
+        "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-n": "^15.1.0",
+        "eslint-plugin-promise": "^6.0.0",
+        "eslint-plugin-react": "^7.28.0",
+        "standard-engine": "^15.0.0"
+      }
+    },
+    "standard-engine": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-15.0.0.tgz",
+      "integrity": "sha512-4xwUhJNo1g/L2cleysUqUv7/btn7GEbYJvmgKrQ2vd/8pkTmN8cpqAZg+BT8Z1hNeEH787iWUdOpL8fmApLtxA==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^8.0.0",
+        "minimist": "^1.2.6",
+        "pkg-conf": "^3.1.0",
+        "xdg-basedir": "^4.0.0"
+      }
     },
     "string_decoder": {
       "version": "1.3.0",
@@ -1847,6 +5537,44 @@
         "strip-ansi": "^6.0.1"
       }
     },
+    "string.prototype.matchall": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.8.tgz",
+      "integrity": "sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.3",
+        "regexp.prototype.flags": "^1.4.3",
+        "side-channel": "^1.0.4"
+      }
+    },
+    "string.prototype.trimend": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
+      "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
+      "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      }
+    },
     "strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -1855,10 +5583,37 @@
         "ansi-regex": "^5.0.1"
       }
     },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true
+    },
     "strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
+    },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
+    },
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true
     },
     "tar-stream": {
       "version": "2.2.0",
@@ -1872,10 +5627,64 @@
         "readable-stream": "^3.1.1"
       }
     },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true
+    },
     "transparent-proxy": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/transparent-proxy/-/transparent-proxy-1.9.1.tgz",
       "integrity": "sha512-1Y32CDNQJrVExGpsJM4ugEHNKYwHHmZL7SZZT7CyYwnMN8upisZYqufWPSXPi5x35Y3q9LWZR2O7sqF5BSiobQ=="
+    },
+    "tsconfig-paths": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
+      "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
+      "dev": true,
+      "requires": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.1",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1"
+      }
+    },
+    "type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true
+    },
+    "unbox-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
+        "which-boxed-primitive": "^1.0.2"
+      }
+    },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -1911,6 +5720,19 @@
         "isexe": "^2.0.0"
       }
     },
+    "which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
+      "requires": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      }
+    },
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
@@ -1923,6 +5745,12 @@
       "requires": {
         "execa": "^5.1.1"
       }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
     },
     "wrap-ansi": {
       "version": "6.2.0",
@@ -1939,10 +5767,22 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
+    "xdg-basedir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
+      "dev": true
+    },
     "y18n": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
       "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "yargs": {
       "version": "15.4.1",
@@ -1970,6 +5810,12 @@
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
       }
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true
     },
     "zip-stream": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "postinstall": "bash postinstall.sh",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "standard-fix": "standard --fix",
+    "test": "standard && node --test"
   },
   "repository": {
     "type": "git",
@@ -36,6 +37,6 @@
   },
   "devDependencies": {
     "@types/node": "^18.11.0",
-    "prettier": "^2.7.1"
+    "standard": "*"
   }
 }

--- a/parsers/MischiefHTTPParser.js
+++ b/parsers/MischiefHTTPParser.js
@@ -3,73 +3,72 @@
  * @module parsers.MischiefHTTPParser
  * @author The Harvard Library Innovation Lab
  * @license MIT
- * @description Utility class for parsing intercepted HTTP exchanges. 
+ * @description Utility class for parsing intercepted HTTP exchanges.
  */
-import { HTTPParser as _HTTPParser } from 'http-parser-js';
+import { HTTPParser as _HTTPParser } from 'http-parser-js'
 
 /**
  * Via: https://github.com/creationix/http-parser-js/blob/master/standalone-example.js
  */
 export class MischiefHTTPParser {
-
-  static headersToMap(headers) {
+  static headersToMap (headers) {
     return Object.fromEntries(
       headers.reduce(
         (result, value, index, sourceArray) =>
           index % 2 === 0 ? [...result, sourceArray.slice(index, index + 2)] : result,
         []
       )
-    );
+    )
   }
 
-  static parseRequest(input) {
-    const parser = new _HTTPParser(_HTTPParser.REQUEST);
-    let complete = false;
-    let shouldKeepAlive;
-    let upgrade;
-    let method;
-    let url;
-    let versionMajor;
-    let versionMinor;
-    let headers = [];
-    let trailers = [];
-    const bodyChunks = [];
+  static parseRequest (input) {
+    const parser = new _HTTPParser(_HTTPParser.REQUEST)
+    let complete = false
+    let shouldKeepAlive
+    let upgrade
+    let method
+    let url
+    let versionMajor
+    let versionMinor
+    let headers = []
+    let trailers = []
+    const bodyChunks = []
 
     parser[_HTTPParser.kOnHeadersComplete] = function (req) {
-      shouldKeepAlive = req.shouldKeepAlive;
-      upgrade = req.upgrade;
-      method = _HTTPParser.methods[req.method];
-      url = req.url;
-      versionMajor = req.versionMajor;
-      versionMinor = req.versionMinor;
-      headers = req.headers;
-    };
+      shouldKeepAlive = req.shouldKeepAlive
+      upgrade = req.upgrade
+      method = _HTTPParser.methods[req.method]
+      url = req.url
+      versionMajor = req.versionMajor
+      versionMinor = req.versionMinor
+      headers = req.headers
+    }
 
     parser[_HTTPParser.kOnBody] = function (chunk, offset, length) {
-      bodyChunks.push(chunk.slice(offset, offset + length));
-    };
+      bodyChunks.push(chunk.slice(offset, offset + length))
+    }
 
     // This is actually the event for trailers, go figure.
     parser[_HTTPParser.kOnHeaders] = function (t) {
-      trailers = t;
-    };
+      trailers = t
+    }
 
     parser[_HTTPParser.kOnMessageComplete] = function () {
-      complete = true;
-    };
+      complete = true
+    }
 
     // Since we are sending the entire Buffer at once here all callbacks above happen synchronously.
     // The parser does not do _anything_ asynchronous.
     // However, you can of course call execute() multiple times with multiple chunks, e.g. from a stream.
     // But then you have to refactor the entire logic to be async (e.g. resolve a Promise in kOnMessageComplete and add timeout logic).
-    parser.execute(input);
-    parser.finish();
+    parser.execute(input)
+    parser.finish()
 
     if (!complete) {
-      throw new Error('Could not parse request');
+      throw new Error('Could not parse request')
     }
 
-    const body = Buffer.concat(bodyChunks);
+    const body = Buffer.concat(bodyChunks)
 
     return {
       shouldKeepAlive,
@@ -80,59 +79,59 @@ export class MischiefHTTPParser {
       versionMinor,
       headers,
       body,
-      trailers,
-    };
+      trailers
+    }
   }
 
   /**
-   * 
-   * @param {*} input 
+   *
+   * @param {*} input
    * @returns {MischiefHTTPParserResponse}
    */
-  static parseResponse(input) {
-    const parser = new _HTTPParser(_HTTPParser.RESPONSE);
-    let complete = false;
-    let shouldKeepAlive;
-    let upgrade;
-    let statusCode;
-    let statusMessage;
-    let versionMajor;
-    let versionMinor;
-    let headers = [];
-    let trailers = [];
-    const bodyChunks = [];
+  static parseResponse (input) {
+    const parser = new _HTTPParser(_HTTPParser.RESPONSE)
+    let complete = false // eslint-disable-line
+    let shouldKeepAlive
+    let upgrade
+    let statusCode
+    let statusMessage
+    let versionMajor
+    let versionMinor
+    let headers = []
+    let trailers = []
+    const bodyChunks = []
 
     parser[_HTTPParser.kOnHeadersComplete] = function (res) {
-      shouldKeepAlive = res.shouldKeepAlive;
-      upgrade = res.upgrade;
-      statusCode = res.statusCode;
-      statusMessage = res.statusMessage;
-      versionMajor = res.versionMajor;
-      versionMinor = res.versionMinor;
-      headers = res.headers;
-    };
+      shouldKeepAlive = res.shouldKeepAlive
+      upgrade = res.upgrade
+      statusCode = res.statusCode
+      statusMessage = res.statusMessage
+      versionMajor = res.versionMajor
+      versionMinor = res.versionMinor
+      headers = res.headers
+    }
 
     parser[_HTTPParser.kOnBody] = function (chunk, offset, length) {
-      bodyChunks.push(chunk.slice(offset, offset + length));
-    };
+      bodyChunks.push(chunk.slice(offset, offset + length))
+    }
 
     // This is actually the event for trailers, go figure.
     parser[_HTTPParser.kOnHeaders] = function (t) {
-      trailers = t;
-    };
+      trailers = t
+    }
 
     parser[_HTTPParser.kOnMessageComplete] = function () {
-      complete = true;
-    };
+      complete = true
+    }
 
     // Since we are sending the entire Buffer at once here all callbacks above happen synchronously.
     // The parser does not do _anything_ asynchronous.
     // However, you can of course call execute() multiple times with multiple chunks, e.g. from a stream.
     // But then you have to refactor the entire logic to be async (e.g. resolve a Promise in kOnMessageComplete and add timeout logic).
-    parser.execute(input);
-    parser.finish();
+    parser.execute(input)
+    parser.finish()
 
-    const body = Buffer.concat(bodyChunks);
+    const body = Buffer.concat(bodyChunks)
 
     return {
       shouldKeepAlive,
@@ -143,11 +142,10 @@ export class MischiefHTTPParser {
       versionMinor,
       headers,
       body,
-      trailers,
-    };
+      trailers
+    }
   }
 }
-
 
 /**
  * Locates the beginning of an HTTP response body
@@ -162,16 +160,15 @@ export class MischiefHTTPParser {
  * @param {Buffer} buffer -
  * @returns {integer} -
  */
-const CRLFx2 = "\r\n\r\n";
-const LFx2 = "\n\n";
-export function bodyStartIndex(buffer) {
+const CRLFx2 = '\r\n\r\n'
+const LFx2 = '\n\n'
+export function bodyStartIndex (buffer) {
   return [CRLFx2, LFx2].reduce((prevEnd, delimiter) => {
-    const start = buffer.indexOf(delimiter);
-    const end = start + delimiter.length;
-    return (start != -1 && (prevEnd == -1 || end < prevEnd)) ? end : prevEnd;
+    const start = buffer.indexOf(delimiter)
+    const end = start + delimiter.length
+    return (start !== -1 && (prevEnd === -1 || end < prevEnd)) ? end : prevEnd
   }, -1)
 }
-
 
 /**
  * Extracts the protocol version from an HTTP status line
@@ -179,6 +176,6 @@ export function bodyStartIndex(buffer) {
  * @param {string} statusLine -
  * @returns {array} -
  */
-export function versionFromStatusLine(statusLine) {
-  return statusLine.match(/\/([\d\.]+)/)[1].split('.').map(n => parseInt(n));
+export function versionFromStatusLine (statusLine) {
+  return statusLine.match(/\/([\d.]+)/)[1].split('.').map(n => parseInt(n))
 }

--- a/parsers/index.js
+++ b/parsers/index.js
@@ -5,6 +5,6 @@
  * @license MIT
  * @description Entry point for the parsers module. Classes in this module are meant to be used to parse raw network traffic (i.e. HTTP).
  */
-import { MischiefHTTPParser } from "./MischiefHTTPParser.js";
+import { MischiefHTTPParser } from './MischiefHTTPParser.js'
 
-export { MischiefHTTPParser };
+export { MischiefHTTPParser }

--- a/test/importers/waczToMischief.js
+++ b/test/importers/waczToMischief.js
@@ -1,27 +1,26 @@
-import test from 'node:test';
-import assert from 'node:assert/strict';
-import { valueOf, defaultTestCaptureOptions } from '../utils.js';
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { valueOf, defaultTestCaptureOptions } from '../utils.js'
 
-import { v4 as uuidv4 } from "uuid";
-import { writeFile, rm } from "fs/promises";
+import { v4 as uuidv4 } from 'uuid'
+import { writeFile, rm } from 'fs/promises'
 
-import { Mischief } from "../../Mischief.js";
-import { MischiefOptions} from "../../MischiefOptions.js";
+import { Mischief } from '../../Mischief.js'
+import { MischiefOptions } from '../../MischiefOptions.js'
 
 test('roundtrip should produce identical mischief', async (_t) => {
   const fpath = `${MischiefOptions.defaults.tmpFolderPath}${uuidv4()}.wacz`
-  const capture = new Mischief('https://example.com', defaultTestCaptureOptions);
-  await capture.capture();
-  const wacz = await capture.toWacz();
+  const capture = new Mischief('https://example.com', defaultTestCaptureOptions)
+  await capture.capture()
+  const wacz = await capture.toWacz()
 
-  let reconstructedCapture;
+  let reconstructedCapture
   try {
-    await writeFile(fpath, Buffer.from(wacz));
-    reconstructedCapture = await Mischief.fromWacz(fpath);
-  }
-  finally {
-    await rm(fpath, {force: true});
+    await writeFile(fpath, Buffer.from(wacz))
+    reconstructedCapture = await Mischief.fromWacz(fpath)
+  } finally {
+    await rm(fpath, { force: true })
   }
 
-  assert.deepEqual(valueOf(reconstructedCapture), valueOf(capture));
+  assert.deepEqual(valueOf(reconstructedCapture), valueOf(capture))
 })

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,19 +1,19 @@
-import { Mischief } from '../Mischief.js';
+import { Mischief } from '../Mischief.js'
 import { MischiefProxyExchange } from '../exchanges/MischiefProxyExchange.js'
 import { MischiefGeneratedExchange } from '../exchanges/MischiefGeneratedExchange.js'
 
 export const defaultTestCaptureOptions = {
   headless: true,
-  captureVideoAsAttachment: false,
+  captureVideoAsAttachment: false
 }
 
-export function valueOf(source) {
-  switch(source.constructor) {
+export function valueOf (source) {
+  switch (source.constructor) {
     case Array: {
-      return source.map(valueOf);
+      return source.map(valueOf)
     }
     case Object: {
-      return Object.fromEntries(Object.entries(source).map(([k, v]) => [k, valueOf(v)]));
+      return Object.fromEntries(Object.entries(source).map(([k, v]) => [k, valueOf(v)]))
     }
     case Mischief: {
       return filterProps(source, [
@@ -21,7 +21,7 @@ export function valueOf(source) {
         'options',
         'provenanceInfo',
         'exchanges'
-      ]);
+      ])
     }
     case MischiefProxyExchange: {
       return filterProps(source, [
@@ -29,7 +29,7 @@ export function valueOf(source) {
         'date',
         'requestRaw',
         'responseRaw'
-      ]);
+      ])
     }
     case MischiefGeneratedExchange: {
       return filterProps(source, [
@@ -37,14 +37,14 @@ export function valueOf(source) {
         'date',
         'description',
         'response'
-      ]);
+      ])
     }
     default: {
-      return source;
+      return source
     }
   }
 }
 
-function filterProps(obj, keep) {
+function filterProps (obj, keep) {
   return Object.fromEntries(keep.map(k => [k, valueOf(obj[k])]))
 }

--- a/utils/WACZ.js
+++ b/utils/WACZ.js
@@ -6,42 +6,41 @@
  * @description WACZ builder.
  */
 
-import path from "path";
-import { Readable, Writable } from "stream";
-import { createHash } from "crypto";
+import path from 'path'
+import { Readable, Writable } from 'stream'
+import { createHash } from 'crypto'
 
-import { CDXIndexer } from "warcio";
-import CONSTANTS from "../constants.js";
-import * as zip from "../utils/zip.js";
+import { CDXIndexer } from 'warcio'
+import CONSTANTS from '../constants.js'
+import * as zip from '../utils/zip.js'
 
 export class WACZ {
-
   validations = [
     [/^archives\//, [this.assertWarc]],
     [/^indexes\//, [this.assertIndex]],
     [/^pages\//, [this.assertPages]]
   ]
 
-  pages = [];
+  pages = []
 
-  datapackage = {};
+  datapackage = {}
 
   /**
    * Additional information to be be added to `datapackage.json`.
    * Will be saved under "extras" if provided.
    * @type {?object}
    */
-  datapackageExtras = null;
+  datapackageExtras = null
 
-  _filesProxy;
+  _filesProxy
 
-  get files() {
-    if(!this._filesProxy){
+  get files () {
+    if (!this._filesProxy) {
       // initialize the proxy on first access
       // if it hasn't already been created
       this.files = {}
     }
-    return this._filesProxy;
+    return this._filesProxy
   }
 
   /**
@@ -49,20 +48,20 @@ export class WACZ {
    *
    * @param {any} obj - an object whose keys are the file paths and values are the file data
    */
-  set files(obj) {
+  set files (obj) {
     // validate all properties on initial assignment
     Object.entries(obj).forEach(([fpath, fdata]) => {
-      return this.validateFile(fpath, fdata);
+      return this.validateFile(fpath, fdata)
     })
 
     // create a new proxy to handle additional assignments to `files`
     this._filesProxy = new Proxy(obj, {
       set: (target, fpath, fdata) => {
-        this.validateFile(fpath, fdata);
-        target[fpath] = fdata;
-        return true;
+        this.validateFile(fpath, fdata)
+        target[fpath] = fdata
+        return true
       }
-    });
+    })
   }
 
   /**
@@ -70,15 +69,15 @@ export class WACZ {
    *
    * @returns {WACZ}
    */
-  constructor(props = {}) {
+  constructor (props = {}) {
     // Only accept props that reflect a defined property of `this`
     for (const [key, value] of Object.entries(props)) {
       if (key in this) {
-        this[key] = value;
+        this[key] = value
       }
     }
 
-    return this;
+    return this
   }
 
   /**
@@ -89,26 +88,26 @@ export class WACZ {
    * @param {string} fpath
    * @param {Buffer} fdata
    */
-  assertWarc(fpath, fdata) {
-    buf = Buffer.from(fdata);
+  assertWarc (fpath, fdata) {
+    const buf = Buffer.from(fdata)
 
     // If the first 4 bytes are "WARC", let's assume it's an uncompressed WARC
-    if(buf.toString('utf8', 0, 4) === 'WARC'){
-        return;
+    if (buf.toString('utf8', 0, 4) === 'WARC') {
+      return
     }
 
-    if(zip.isZip(buf)){
-      if(!/\.warc\.gz$/.test(fpath)) {
-        throw `${fpath}: must use .warc.gz extension when using zip`
-      } else if(!zip.usesStoreCompression(fdata)){
-        throw `${fpath}: must use STORE when compressing the zip`
-      } else if(zip.readBodyAsString(fdata, 4) === 'WARC') {
-        return;
+    if (zip.isZip(buf)) {
+      if (!/\.warc\.gz$/.test(fpath)) {
+        throw new Error(`${fpath}: must use .warc.gz extension when using zip`)
+      } else if (!zip.usesStoreCompression(fdata)) {
+        throw new Error(`${fpath}: must use STORE when compressing the zip`)
+      } else if (zip.readBodyAsString(fdata, 4) === 'WARC') {
+        return
       }
     }
 
     // None of the WARC sniff tests passed so throw a final error
-    throw `${fpath}: must be a valid WARC file`;
+    throw new Error(`${fpath}: must be a valid WARC file`)
   }
 
   /**
@@ -119,14 +118,14 @@ export class WACZ {
    * @param {string} fpath
    * @param {Buffer} fdata
    */
-  assertIndex(fpath, fdata) {
+  assertIndex (fpath, fdata) {
     // CDXJ's are newline delineated
-    const lines = Buffer.from(fdata).toString().split('\n');
+    const lines = Buffer.from(fdata).toString().split('\n')
     // Grab the JSON blob from the first line and parse it
-    const json = JSON.parse(lines[0].split(/ \d{14} /)[1]);
+    const json = JSON.parse(lines[0].split(/ \d{14} /)[1])
     // Use the url property of the JSON as a sniff test
-    if(!json.url){
-      throw `${fpath}: must be a valid CDXJ file`;
+    if (!json.url) {
+      throw new Error(`${fpath}: must be a valid CDXJ file`)
     }
   }
 
@@ -138,16 +137,16 @@ export class WACZ {
    * @param {string} fpath
    * @param {Buffer} fdata
    */
-  assertPages(fpath, fdata) {
+  assertPages (fpath, fdata) {
     // Parse the lines of JSON data
-    const lines = Buffer.from(fdata).toString().split('\n').map(JSON.parse);
+    const lines = Buffer.from(fdata).toString().split('\n').map(JSON.parse)
     // Get the last entry to avoid the first line header
-    const entry = lines[lines.length - 1];
+    const entry = lines[lines.length - 1]
     // Both `url` and `ts` are required per the spec
-    if(!entry.url) {
-      throw `${fpath}: must be a valid JSON-Lines file with url properties`;
-    } else if(!entry.ts) {
-      throw `${fpath}: must be a valid JSON-Lines file with ts properties`;
+    if (!entry.url) {
+      throw new Error(`${fpath}: must be a valid JSON-Lines file with url properties`)
+    } else if (!entry.ts) {
+      throw new Error(`${fpath}: must be a valid JSON-Lines file with ts properties`)
     }
   }
 
@@ -158,12 +157,12 @@ export class WACZ {
    * @param {string} fpath
    * @param {Buffer} fdata
    */
-  validateFile(fpath, fdata) {
+  validateFile (fpath, fdata) {
     this.validations
-        .filter(([regex]) => regex.test(fpath))
-        .forEach(([,assertions]) => {
-          assertions.forEach(assert => assert(fpath, fdata))
-        });
+      .filter(([regex]) => regex.test(fpath))
+      .forEach(([, assertions]) => {
+        assertions.forEach(assert => assert(fpath, fdata))
+      })
   }
 
   /**
@@ -175,44 +174,43 @@ export class WACZ {
    * @param {any} [files=this.files] - an object whose keys are the file paths and values are the file data
    * @returns {Promise<Buffer>} - a buffer with the contents of the CDXJ Index
    */
-  async generateIndexCDX(files = this.files) {
-    const buffers = [];
-    const converter = new Writable();
+  async generateIndexCDX (files = this.files) {
+    const buffers = []
+    const converter = new Writable()
     converter._write = (chunk, _encoding, cb) => {
       buffers.push(chunk)
       process.nextTick(cb)
     }
 
     const warcs = Object.entries(files)
-                        .filter(([fpath]) => /^archive\//.test(fpath))
-                        .map(([fpath, fdata]) => {
-                          return {
-                            filename: path.basename(fpath),
-                            reader: Readable.from(fdata)
-                          }
-                        })
+      .filter(([fpath]) => /^archive\//.test(fpath))
+      .map(([fpath, fdata]) => {
+        return {
+          filename: path.basename(fpath),
+          reader: Readable.from(fdata)
+        }
+      })
 
-    await new CDXIndexer({format: 'cdxj'}, converter).run(warcs);
-    return Buffer.concat(buffers);
+    await new CDXIndexer({ format: 'cdxj' }, converter).run(warcs)
+    return Buffer.concat(buffers)
   }
-
 
   /**
    * Generates a JSON-Lines formatted list of pages
    *
    * @returns {Buffer} - a buffer with the contents of the pages files
    */
-  generatePages() {
+  generatePages () {
     const pages = [
       {
-        format: "json-pages-1.0",
-        id: "pages",
-        title: "All Pages",
+        format: 'json-pages-1.0',
+        id: 'pages',
+        title: 'All Pages'
       },
-      ...this.pages,
-    ];
+      ...this.pages
+    ]
 
-    return Buffer.from(pages.map(JSON.stringify).join("\n"));
+    return Buffer.from(pages.map(JSON.stringify).join('\n'))
   }
 
   /**
@@ -220,12 +218,12 @@ export class WACZ {
    *
    * @returns {string} - a string with the contents of the datapackage
    */
-  generateDatapackage() {
-    const datapackage = {... this.datapackage};
-    datapackage.profile = "data-package";
-    datapackage.wacz_version = CONSTANTS.WACZ_VERSION;
-    datapackage.software = `${CONSTANTS.SOFTWARE} ${CONSTANTS.VERSION}`;
-    datapackage.created = (new Date()).toISOString();
+  generateDatapackage () {
+    const datapackage = { ...this.datapackage }
+    datapackage.profile = 'data-package'
+    datapackage.wacz_version = CONSTANTS.WACZ_VERSION
+    datapackage.software = `${CONSTANTS.SOFTWARE} ${CONSTANTS.VERSION}`
+    datapackage.created = (new Date()).toISOString()
 
     datapackage.resources = Object.entries(this.files).map(([fpath, fdata]) => {
       return {
@@ -234,21 +232,21 @@ export class WACZ {
         hash: hash(fdata),
         bytes: fdata.byteLength
       }
-    });
+    })
 
     // Set `mainPageUrl` and `mainPageDate`: pick first entry in `this.pages` that starts with "http"
-    const mainPage = this.pages.find(page => page.url.startsWith("http"))
-    if (mainPage) { 
-      datapackage.mainPageUrl = mainPage.url;
-      datapackage.mainPageDate = mainPage.ts;
+    const mainPage = this.pages.find(page => page.url.startsWith('http'))
+    if (mainPage) {
+      datapackage.mainPageUrl = mainPage.url
+      datapackage.mainPageDate = mainPage.ts
     }
 
     // Append additional data under "extras" if provided
     if (this.datapackageExtras) {
-      datapackage.extras = this.datapackageExtras;
+      datapackage.extras = this.datapackageExtras
     }
 
-    return stringify(datapackage);
+    return stringify(datapackage)
   }
 
   /**
@@ -256,15 +254,15 @@ export class WACZ {
    *
    * @returns {string} - a string with the contents of the datapackage-digest
    */
-  generateDatapackageDigest() {
-    if(!this.files["datapackage.json"]){
-      throw "datapackage.json must be present to generate datapackage-digest.json"
+  generateDatapackageDigest () {
+    if (!this.files['datapackage.json']) {
+      throw new Error('datapackage.json must be present to generate datapackage-digest.json')
     }
 
     return stringify({
       path: 'datapackage.json',
       hash: hash(this.files['datapackage.json'])
-    });
+    })
   }
 
   /**
@@ -274,33 +272,30 @@ export class WACZ {
    * @param {boolean} [autoindex=true] - automatically create a CDXJ index
    * @returns {Promise<Buffer>} - a buffer with the zipped contents of the WACZ
    */
-  async finalize(autoindex = true) {
-    if(dirEmpty(this.files, "archive")){
-      throw "at least one WARC must be present in the archive directory";
+  async finalize (autoindex = true) {
+    if (dirEmpty(this.files, 'archive')) {
+      throw new Error('at least one WARC must be present in the archive directory')
     }
 
     if (autoindex) {
-      const index = await this.generateIndexCDX();
-      this.files["indexes/index.cdx"] = index;
-    } 
-    else if (dirEmpty(this.files, "indexes")) {
-      throw "at least one CDXJ index must be present in the indexes directory";
+      const index = await this.generateIndexCDX()
+      this.files['indexes/index.cdx'] = index
+    } else if (dirEmpty(this.files, 'indexes')) {
+      throw new Error('at least one CDXJ index must be present in the indexes directory')
     }
 
     if (this.pages.length) {
-      this.files["pages/pages.jsonl"] = this.generatePages();
-    } 
-    else {
-      throw "at least one page must be present";
+      this.files['pages/pages.jsonl'] = this.generatePages()
+    } else {
+      throw new Error('at least one page must be present')
     }
 
     // Always autogenerated
-    this.files['datapackage.json'] = this.generateDatapackage();
-    this.files['datapackage-digest.json'] = this.generateDatapackageDigest();
+    this.files['datapackage.json'] = this.generateDatapackage()
+    this.files['datapackage-digest.json'] = this.generateDatapackageDigest()
 
-    return await zip.create(this.files);
+    return await zip.create(this.files)
   }
-
 }
 
 // Internal helpers
@@ -314,8 +309,8 @@ export class WACZ {
  * @returns {boolean} -
  */
 const dirEmpty = (files, dir) => {
-  const regex = new RegExp(`^${dir}\/.+`);
-  return !Object.entries(files).find(([fpath]) => regex.test(fpath));
+  const regex = new RegExp(`^${dir}/.+`)
+  return !Object.entries(files).find(([fpath]) => regex.test(fpath))
 }
 
 /**
@@ -324,7 +319,7 @@ const dirEmpty = (files, dir) => {
  * @param {any} obj - an JS object
  * @returns {string} - a JSON string
  */
-const stringify = (obj) => JSON.stringify(obj, null, 2);
+const stringify = (obj) => JSON.stringify(obj, null, 2)
 
 /**
  * Hashes a buffer to conform to the WACZ spec
@@ -332,8 +327,8 @@ const stringify = (obj) => JSON.stringify(obj, null, 2);
  * @param {Buffer} buffer
  * @returns {string} - a sha256 hash prefixed with "sha256:"
  */
-export function hash(buffer){
-  return 'sha256:' + createHash('sha256').update(buffer).digest('hex');
+export function hash (buffer) {
+  return 'sha256:' + createHash('sha256').update(buffer).digest('hex')
 }
 
 /**
@@ -343,7 +338,7 @@ export function hash(buffer){
  * @param {MischiefExchange} exchange
  * @returns {object}
  */
-export function mischiefExchangeToPageLine(exchange) {
+export function mischiefExchangeToPageLine (exchange) {
   return {
     id: exchange.id,
     url: exchange.response.url,

--- a/utils/zip.js
+++ b/utils/zip.js
@@ -1,5 +1,5 @@
-import { Writable } from "stream";
-import Archiver from "archiver";
+import { Writable } from 'stream'
+import Archiver from 'archiver'
 
 /**
  * Sniffs a buffer to loosely infer whether it's a zip file
@@ -10,8 +10,8 @@ import Archiver from "archiver";
  * @param {Buffer} buf
  * @returns {boolean}
  */
-export function isZip(buf) {
-  return buf.toString('utf8', 0, 2) === 'PK';
+export function isZip (buf) {
+  return buf.toString('utf8', 0, 2) === 'PK'
 }
 
 /**
@@ -21,8 +21,8 @@ export function isZip(buf) {
  * @param {Buffer} buf
  * @returns {boolean}
  */
-export function usesStoreCompression(buf) {
-  return buf.readUIntLE(8, 2) === 0;
+export function usesStoreCompression (buf) {
+  return buf.readUIntLE(8, 2) === 0
 }
 
 /**
@@ -33,8 +33,8 @@ export function usesStoreCompression(buf) {
  * @param {Buffer} buf
  * @returns {integer}
  */
-export function fileNameLen(buf) {
-  return buf.readUIntLE(26, 2);
+export function fileNameLen (buf) {
+  return buf.readUIntLE(26, 2)
 }
 
 /**
@@ -45,8 +45,8 @@ export function fileNameLen(buf) {
  * @param {Buffer} buf
  * @returns {integer}
  */
-export function extraFieldLen(buf) {
-  return buf.readUIntLE(28, 2);
+export function extraFieldLen (buf) {
+  return buf.readUIntLE(28, 2)
 }
 
 /**
@@ -57,8 +57,8 @@ export function extraFieldLen(buf) {
  * @param {integer} byteLen
  * @returns {string}
  */
-export function readBodyAsString(buf, byteLen) {
-  return buf.toString(30 + fileNameLen(buf) + extraFieldLen(buf), byteLen);
+export function readBodyAsString (buf, byteLen) {
+  return buf.toString(30 + fileNameLen(buf) + extraFieldLen(buf), byteLen)
 }
 
 /**
@@ -68,21 +68,21 @@ export function readBodyAsString(buf, byteLen) {
  * @param {boolean} [store=true] - should store compression be used?
  * @returns {Promise<Buffer>} - a buffer containing the zipped data
  */
-export async function create(files, store = true) {
-  const archive = new Archiver('zip', {store});
+export async function create (files, store = true) {
+  const archive = new Archiver('zip', { store })
 
-  const buffers = [];
-  const converter = new Writable();
+  const buffers = []
+  const converter = new Writable()
   converter._write = (chunk, _encoding, cb) => {
-    buffers.push(chunk);
-    process.nextTick(cb);
+    buffers.push(chunk)
+    process.nextTick(cb)
   }
-  archive.pipe(converter);
+  archive.pipe(converter)
 
   Object.entries(files).forEach(([name, data]) => {
-    archive.append(data, {name})
+    archive.append(data, { name })
   })
 
-  await archive.finalize();
-  return Buffer.concat(buffers);
+  await archive.finalize()
+  return Buffer.concat(buffers)
 }


### PR DESCRIPTION
Testing out [Standard JS](https://github.com/standard/standard) on this project.
Although there are a few rules of Standard JS I personally don't like, I really like the idea of having a set code formatting standard that can be automatically enforced, so we can focus our energy on something else in the last stretch.

I added it as a step of `npm run test`, and left a `.vscode` folder with presets for on-the-fly reporting and formatting. I _think_ this would also work with GitHub's embedded version of VS Code.

I also added a shortcut for codebase-wide autofixing (`npm run standard-fix`).

Cheers. 