### PR TITLE
Extracted Video Summary: (Incomplete) Safari video playback fix

### DIFF
--- a/assets/video-extracted-summary.njk
+++ b/assets/video-extracted-summary.njk
@@ -106,7 +106,8 @@
         <h2>Video</h2>
 
         {% if videoSaved %}
-        <video src="video-extracted.mp4" controls>
+        <video controls>
+          <source src="video-extracted.mp4" type="video/mp4" />
           {% if subtitlesSaved and subtitlesFormat == 'vtt' %}
             {% for locale in subtitlesAvailableLocales %}
             <track 


### PR DESCRIPTION
Tracked here: https://github.com/harvard-lil/mischief/issues/62#issuecomment-1351886577 

---

This PR edits the `<video>` tag in `video-extracted-summary.njk` in order to fix a Safari video playback issues identified by @leppert.

This is unfortunately a partial fix: the player is now working properly, but another issue - likely replayweb.page-specific - is preventing Safari from streaming the video on first try: accessing the `.mp4` file directly first circumvents this problem. 

Preloading might help but unfortunately.  [support for `<preload as="video">` is not yet implemented by browsers](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preload#what_types_of_content_can_be_preloaded). 

https://user-images.githubusercontent.com/625889/207871123-fb554c4c-3c12-43d9-83cc-20ecb249f0ed.mov

Will ask Ilya for thoughts 😄, but I think this falls out of Mischief's scope. 
