### PR TITLE
Mischief.pageInfo

### DIFF
--- a/Mischief.js
+++ b/Mischief.js
@@ -502,7 +502,7 @@ export class Mischief {
       try {
         const response = await fetch(this.pageInfo.faviconUrl)
 
-        if (!response.headers.get('content-type').startsWith('image/')) {
+        if (!response.headers?.get('content-type')?.startsWith('image/')) {
           throw new Error(`Request for favicon returned mime type ${response.headers.get('content-type')}`)
         }
 


### PR DESCRIPTION
Implements https://github.com/harvard-lil/mischief/issues/62#issuecomment-1351835974 

Utility / convenience method for extracting basic page info: 
- title
- description
- actual url
- favicon 

This was also the opportunity to discover that Chrome does _not_ attempt to load the favicon in headless mode, and to palliate for that. I ended up fetching it out-of-band and adding it as a generated exchange in that case. 

While this is feature is most likely needed for Perma's integration, to be added to the "unifying developer experience" discussion 😄 .