### PR TITLE
WACZ Signing fix (wrong property name)

### DIFF
--- a/utils/WACZ.js
+++ b/utils/WACZ.js
@@ -271,7 +271,7 @@ export class WACZ {
     }
 
     if (this.signingServer) {
-      digest.signatureData = await this.requestSignature({ hash: digest.hash, created: this.created })
+      digest.signedData = await this.requestSignature({ hash: digest.hash, created: this.created })
     }
 
     return stringify(digest)


### PR DESCRIPTION
Turns out that https://specs.webrecorder.net/wacz-auth/0.1.0/ is actually behind the latest revisions of the spec 🤷 . [`signatureData` should apparently be `signedData`](https://github.com/webrecorder/specs/blob/main/wacz-auth/spec.md#wacz-signature-file-and-format). 

replayweb.page, authsign and py-wacz are looking for `signedData`. I will ask webrecorder to clarify.