### PR TITLE
Unit tests: exchanges module (edits)

### DIFF
--- a/exchanges/MischiefExchange.js
+++ b/exchanges/MischiefExchange.js
@@ -73,4 +73,6 @@ export class MischiefExchange {
  * @property {object} headers
  * @property {Buffer} body
  * @property {Array} trailers
+ * @property {?number} statusCode - Response only
+ * @property {?string} statusMessage - Response only
  */

--- a/exchanges/MischiefProxyExchange.test.js
+++ b/exchanges/MischiefProxyExchange.test.js
@@ -49,6 +49,9 @@ test('MischiefProxyExchange request and response properties populate automatical
       assert(newObj.body instanceof Buffer)
       assert.deepEqual(newObj.body, refObj.body)
 
+      assert(typeof newObj.url === 'string')
+      assert(newObj.url === refObj.url)
+
       if (key === 'response') {
         assert(typeof newObj.statusCode === 'number')
         assert(newObj.statusCode === refObj.statusCode)


### PR DESCRIPTION
As discussed on Slack:
- We should be testing `MischiefProxyExchange.url`
- Completed `MischiefExchange~RequestOrResponse` typedef