### PR TITLE
Temporary fix for "noarchive" directive check

### DIFF
--- a/intercepters/ScoopIntercepter.js
+++ b/intercepters/ScoopIntercepter.js
@@ -3,6 +3,7 @@ import { parse as parseHTML } from 'node-html-parser'
 
 import { Scoop } from '../Scoop.js'
 import { bodyToString } from '../utils/http.js'
+import { ScoopProxyExchange } from '../exchanges/ScoopProxyExchange.js'
 
 /**
  * @class ScoopIntercepter
@@ -92,6 +93,11 @@ export class ScoopIntercepter {
    * @returns {boolean} - `true` if request contained "noarchive"
    */
   async checkExchangeForNoArchive (exchange) {
+    // Exit early if exchange is not a ScoopProxyExchange
+    if (exchange instanceof ScoopProxyExchange === false) {
+      return false
+    }
+
     // Exit early if this isn't an HTML document
     if (!exchange?.response?.bodyCombined ||
         !exchange?.response?.headers?.get('content-type')?.toLowerCase().startsWith('text/html')) {
@@ -124,7 +130,7 @@ export class ScoopIntercepter {
     }
 
     // If we reached this point: this exchange is "noarchive".
-    this.capture.log.info(`${exchange.url} was tagged with the "noarchive" directive.`)
+    this.capture.log.warn(`${exchange.url} was tagged with the "noarchive" directive.`)
     this.capture.provenanceInfo.noArchiveUrls.push(exchange.url)
     return true
   }

--- a/intercepters/ScoopProxy.js
+++ b/intercepters/ScoopProxy.js
@@ -164,9 +164,13 @@ export class ScoopProxy extends ScoopIntercepter {
     const prop = `${type}Raw` // `responseRaw` | `requestRaw`
     ex[prop] = ex[prop] ? Buffer.concat([ex[prop], data], ex[prop].length + data.length) : data
 
+    // NOTE: Temporarily moved as a capture step until this proxy is replaced.
+    // The main issue was that we could not easily identify "when" to run this step, resulting in multiple, unnecessary calls.
+    /*
     if (type === 'response') {
       this.checkExchangeForNoArchive(ex)
     }
+    */
 
     this.byteLength += data.byteLength
     this.checkAndEnforceSizeLimit() // From parent

--- a/options.js
+++ b/options.js
@@ -27,7 +27,7 @@ export const defaults = {
   autoScroll: true,
   autoPlayMedia: true,
   grabSecondaryResources: true,
-  runSiteSpecificBehaviors: false,
+  runSiteSpecificBehaviors: true,
 
   headless: true,
   userAgentSuffix: '',

--- a/options.types.js
+++ b/options.types.js
@@ -23,7 +23,7 @@
  * @property {boolean} autoScroll=true - Should Scoop try to scroll through the page?
  * @property {boolean} autoPlayMedia=true - Should Scoop try to autoplay `<audio>` and `<video>` tags?
  * @property {boolean} grabSecondaryResources=true - Should Scoop try to download img srcsets and secondary stylesheets?
- * @property {boolean} runSiteSpecificBehaviors=false - Should Scoop run site-specific capture behaviors? (via: browsertrix-behaviors)
+ * @property {boolean} runSiteSpecificBehaviors=true - Should Scoop run site-specific capture behaviors? (via: browsertrix-behaviors)
  *
  * @property {boolean} headless=true - Should Playwright run in headless mode?
  * @property {string} userAgentSuffix="" - String to append to the user agent.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@harvard-lil/js-wacz": "^0.0.6",
         "@laverdet/beaugunderson-ip-address": "^8.1.0",
-        "browsertrix-behaviors": "^0.4.1",
+        "browsertrix-behaviors": "^0.4.2",
         "chalk": "^5.2.0",
         "commander": "^10.0.0",
         "get-os-info": "^1.0.2",
@@ -602,9 +602,9 @@
       }
     },
     "node_modules/browsertrix-behaviors": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/browsertrix-behaviors/-/browsertrix-behaviors-0.4.1.tgz",
-      "integrity": "sha512-zG6eNWqT9z+WvdUSSWg6de8NtYnGs7MHpzezKUgMJg+ze1+xtBgc6jkLT1d64eXC0cZQgwW+WV/e0yLAi1PyPA=="
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/browsertrix-behaviors/-/browsertrix-behaviors-0.4.2.tgz",
+      "integrity": "sha512-5w6kPL3NB/BkmEGxWt3NT3iddAaSzMR1TtDPS7b66fM9kkhpCjCv/R/zR951jWDIeV3flJFBOy09uI5o8asPqg=="
     },
     "node_modules/buffer": {
       "version": "5.7.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@harvard-lil/js-wacz": "^0.0.6",
     "@laverdet/beaugunderson-ip-address": "^8.1.0",
-    "browsertrix-behaviors": "^0.4.1",
+    "browsertrix-behaviors": "^0.4.2",
     "chalk": "^5.2.0",
     "commander": "^10.0.0",
     "get-os-info": "^1.0.2",


### PR DESCRIPTION
Moved calls to `ScoopIntercepter.checkExchangeForNoArchive()` to a capture step until proxy is replaced. This ensures this method runs only once per response.

## Misc
- browsertrix-behaviors update.
- `runSiteSpecificBehaviors` default is now `true`
- Better error reporting for `Scoop.filterUrl()`