### PR TITLE
Proxy exception handling fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,14 @@ scoop "https://lil.law.harvard.edu" -f warc -o my-collection/lil.warc
 scoop "https://lil.law.harvard.edu" --headless false
 
 # Although it comes with "good defaults", scoop is highly configurable ...
+# timeout-related options are good 
 scoop "https://lil.law.harvard.edu" --capture-video-as-attachment false --screenshot false --capture-window-x 320 --capture-window-y 480 --capture-timeout 30000 --max-capture-size 100000 --signing-url "https://example.com/sign"
 
 # ... use --help to list the available options, and see what the defaults are.
 scoop --help
+
+# Timeout-related options are good dials to turn first when trying to customize "how much" of a page to capture.
+scoop "https://lil.law.harvard.edu" --capture-timeout 90000 --load-timeout 60000 --network-idle-timeout 30000
 ```
 
 <details>

--- a/intercepters/ScoopProxy.js
+++ b/intercepters/ScoopProxy.js
@@ -100,9 +100,17 @@ export class ScoopProxy extends ScoopIntercepter {
     const ip = session._dst.remoteAddress
 
     // https doesn't have the protocol or host in the path so add it here
-    const url = (session.request.path[0] === '/')
-      ? `https://${session.request.headers.host}${session.request.path}`
-      : session.request.path
+    let url = ''
+
+    try {
+      url = (session.request.path[0] === '/')
+        ? `https://${session.request.headers.host}${session.request.path}`
+        : session.request.path
+    } catch (err) {
+      this.capture.log.trace(err)
+      this.capture.log.warn('A session was skipped (missing "path")')
+      return true
+    }
 
     // Search for a blocklist match:
     // Use the index to pull the original un-parsed rule from options so that the printing matches user expectations

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scoop",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scoop",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harvard-lil/scoop",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "🍨 High-fidelity, browser-based, single-page web archiving library and CLI.",
   "main": "Scoop.js",
   "type": "module",


### PR DESCRIPTION
Discovered after `-g` install: this portion of `ScoopProxy` needs exception handling, in case the session has no `path`.