### PR TITLE
0.0.3 (post launch fixes)

### DIFF
--- a/Scoop.js
+++ b/Scoop.js
@@ -250,8 +250,17 @@ export class Scoop {
       steps.push({
         name: 'Browser scripts',
         setup: async (page) => {
+          // Determine path of `behaviors.js`
+          let behaviorsPath = './node_modules/browsertrix-behaviors/dist/behaviors.js'
+
+          try {
+            await access(behaviorsPath)
+          } catch (_err) {
+            behaviorsPath = `${CONSTANTS.BASE_PATH}/node_modules/browsertrix-behaviors/dist/behaviors.js`
+          }
+
           await page.addInitScript({
-            path: `${CONSTANTS.BASE_PATH}${sep}node_modules${sep}browsertrix-behaviors${sep}dist${sep}behaviors.js`
+            path: behaviorsPath
           })
           await page.addInitScript({
             content: `

--- a/Scoop.js
+++ b/Scoop.js
@@ -3,7 +3,6 @@
 import os from 'os'
 import { readFile, rm, readdir, mkdir, mkdtemp, access } from 'fs/promises'
 import { constants as fsConstants } from 'node:fs'
-import { sep } from 'path'
 import { createHash } from 'crypto'
 
 import log from 'loglevel'
@@ -256,7 +255,7 @@ export class Scoop {
           try {
             await access(behaviorsPath)
           } catch (_err) {
-            behaviorsPath = `${CONSTANTS.BASE_PATH}/node_modules/browsertrix-behaviors/dist/behaviors.js`
+            behaviorsPath = `${CONSTANTS.BASE_PATH}node_modules/browsertrix-behaviors/dist/behaviors.js`
           }
 
           await page.addInitScript({

--- a/intercepters/ScoopProxy.js
+++ b/intercepters/ScoopProxy.js
@@ -108,8 +108,8 @@ export class ScoopProxy extends ScoopIntercepter {
         : session.request.path
     } catch (err) {
       this.capture.log.trace(err)
-      this.capture.log.warn('A session was skipped (missing "path")')
-      return true
+      this.capture.log.warn('A session was skipped (missing "path" / parsing error)')
+      return false
     }
 
     // Search for a blocklist match:

--- a/intercepters/ScoopProxy.js
+++ b/intercepters/ScoopProxy.js
@@ -108,7 +108,7 @@ export class ScoopProxy extends ScoopIntercepter {
         : session.request.path
     } catch (err) {
       this.capture.log.trace(err)
-      this.capture.log.warn('A session was skipped (missing "path" / parsing error)')
+      this.capture.log.warn('A session could not be intercepted for comparison against the blocklist (parsing error). Skipping.')
       return false
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "scoop",
-  "version": "0.0.2",
+  "name": "@harvard-lil/scoop",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "scoop",
-      "version": "0.0.2",
+      "name": "@harvard-lil/scoop",
+      "version": "0.0.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -23,7 +23,7 @@
         "node-stream-zip": "^1.15.0",
         "nunjucks": "^3.2.3",
         "playwright": "^1.31.2",
-        "transparent-proxy": "^1.9.1",
+        "transparent-proxy": "1.9.1",
         "uuid": "^9.0.0",
         "warcio": "^2.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harvard-lil/scoop",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "🍨 High-fidelity, browser-based, single-page web archiving library and CLI.",
   "main": "Scoop.js",
   "type": "module",
@@ -57,7 +57,7 @@
     "node-stream-zip": "^1.15.0",
     "nunjucks": "^3.2.3",
     "playwright": "^1.31.2",
-    "transparent-proxy": "^1.9.1",
+    "transparent-proxy": "1.9.1",
     "uuid": "^9.0.0",
     "warcio": "^2.0.1"
   },


### PR DESCRIPTION
- Freezes `transparent-proxy` version to circumvent parsing issue affecting exchanges intercepted from `yt-dlp` (everything appeared to be merged together under `body`)
- Fixes access to `node_modules` for `browsertrix-behaviors`