### PR TITLE
WACZ Export: Scoop version fix

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -11,11 +11,6 @@ import chalk from 'chalk'
 export const SOFTWARE = 'Scoop @ Harvard Library Innovation Lab'
 
 /**
- * The current version of Scoop. Also used in provenance data.
- */
-export const VERSION = '0.0.1'
-
-/**
  * The version of WARC this library exports
  */
 export const WARC_VERSION = '1.1'
@@ -85,3 +80,8 @@ export const LOGGING_COLORS = {
 export const PACKAGE_INFO = Object.freeze(
   JSON.parse(await fs.readFile(join(BASE_PATH, 'package.json')))
 )
+
+/**
+ * The current version of Scoop. Also used in provenance data.
+ */
+export const VERSION = PACKAGE_INFO.version

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harvard-lil/scoop",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@harvard-lil/scoop",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harvard-lil/scoop",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "🍨 High-fidelity, browser-based, single-page web archiving library and CLI.",
   "main": "Scoop.js",
   "type": "module",


### PR DESCRIPTION
**Fix:** Always source software version from `package.json`.