### PR TITLE
Limits enforcement tweak

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ scoop "https://lil.law.harvard.edu" --capture-timeout 90000 --load-timeout 60000
   <summary><strong>See: Output of scoop --help 🔍</strong></summary>
 
 ```
-Usage: @harvard-lil/scoop [options] <url>
+Usage: scoop [options] <url>
 
 🍨 High-fidelity, browser-based, single-page web archiving library and CLI.
 More info: https://github.com/harvard-lil/scoop

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ npm install -g @harvard-lil/scoop
 npm install @harvard-lil/scoop --save
 
 # In both cases, you may need to install Playwright's dependencies: 
-sudo npx playwright install-deps
+sudo npx playwright install-deps chromium
 ```
 
 <details>
@@ -154,7 +154,7 @@ scoop "https://lil.law.harvard.edu" --capture-timeout 90000 --load-timeout 60000
   <summary><strong>See: Output of scoop --help 🔍</strong></summary>
 
 ```
-Usage: scoop [options] <url>
+Usage: @harvard-lil/scoop [options] <url>
 
 🍨 High-fidelity, browser-based, single-page web archiving library and CLI.
 More info: https://github.com/harvard-lil/scoop
@@ -170,6 +170,7 @@ Options:
   --dom-snapshot <bool>                           Add DOM snapshot step to capture? (choices: "true", "false", default: "false")
   --capture-video-as-attachment <bool>            Add capture video(s) as attachment(s) step to capture? (choices: "true", "false", default: "true")
   --provenance-summary <bool>                     Add provenance summary to capture? (choices: "true", "false", default: "true")
+  --attachments-bypass-limits <bool>              If active, attachments will not count towards time and size constraints imposed on capture. (choices: "true", "false", default: "true")
   --capture-timeout <number>                      Maximum time allocated to capture process before hard cut-off, in ms. (default: 60000)
   --load-timeout <number>                         Max time Scoop will wait for the page to load, in ms. (default: 20000)
   --network-idle-timeout <number>                 Max time Scoop will wait for the in-browser networking tasks to complete, in ms. (default: 20000)

--- a/Scoop.test.js
+++ b/Scoop.test.js
@@ -99,7 +99,7 @@ await test('Scoop - capture of a non-web resource.', async (t) => {
   const PORT = 3000
   const URL = `http://localhost:${PORT}`
 
-  const options = { logLevel: 'silent', headless: true, blocklist: [] }
+  const options = { logLevel: 'silent', headless: true, blocklist: [], attachmentsBypassLimits: false }
 
   const testPdfFixture = await readFile(`${FIXTURES_PATH}test.pdf`)
 
@@ -125,9 +125,10 @@ await test('Scoop - capture of a non-web resource.', async (t) => {
   })
 
   await t.test('Scoop out-of-browser capture accounts for captureTimeout', async (_t) => {
-    const { exchanges: [html] } = await Scoop.capture(`${URL}/test.pdf`, { ...options, captureTimeout: 10 })
-    assert.notEqual(html.response.body.byteLength, 0)
-    assert.notEqual(html.response.body, testPdfFixture)
+    const { exchanges: [html] } = await Scoop.capture(`${URL}/test.pdf`, { ...options, captureTimeout: 100 })
+    assert.equal(html, undefined) // Scoop's intercepter shouldn't have had time to boot up
+    // assert.notEqual(html.response.body.byteLength, testPdfFixture.byteLength)
+    // assert.notEqual(html.response.body, testPdfFixture)
   })
 
   /*

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -19,7 +19,7 @@ const defaults = Scoop.defaults
 // Program info
 //
 program
-  .name(PACKAGE_INFO.name)
+  .name('scoop')
   .description(`${PACKAGE_INFO.description}\nMore info: https://github.com/harvard-lil/scoop`)
   .version(PACKAGE_INFO.version, '-v, --version', 'Display Scoop and Scoop CLI version.')
   .helpOption(null, 'Show options list.')

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -84,6 +84,12 @@ program.addOption(
     .default(String(defaults.captureVideoAsAttachment))
 )
 
+program.addOption(
+  new Option('--attachments-bypass-limits <bool>', 'If active, attachments will not count towards time and size constraints imposed on capture.')
+    .choices(['true', 'false'])
+    .default(String(defaults.attachmentsBypassLimits))
+)
+
 //
 // Timeouts
 //

--- a/options.js
+++ b/options.js
@@ -12,6 +12,7 @@ export const defaults = {
   domSnapshot: false,
   captureVideoAsAttachment: true,
   provenanceSummary: true,
+  attachmentsBypassLimits: true,
 
   captureTimeout: 60 * 1000,
   loadTimeout: 20 * 1000,

--- a/options.types.js
+++ b/options.types.js
@@ -8,6 +8,7 @@
  * @property {boolean} domSnapshot=false - Should Scoop save a snapshot of the rendered DOM? Added as `file:///dom-snapshot.html` in the exchanges list.
  * @property {boolean} captureVideoAsAttachment=true - Should Scoop try to sae the main video(s) present on this page? Added as `file://` attachments, summarized under `file:///video-extracted-summary.html`. This capture happens out of the browser.
  * @property {boolean} provenanceSummary=true - If `true`, information about the capture process (public IP address, User Agent, software version ...) will be gathered and summarized under `file:///provenance-summary.html`. WACZ exports will also hold that information at `datapackage.json` level, under `extras`.
+ * @property {boolean} attachmentsBypassLimits=true - If `true`, "attachments" will not count towards the time and size constraints imposed on capture.
  *
  * @property {number} captureTimeout=60000 - How long should Scoop wait for all steps in the capture to complete, in ms?
  * @property {number} loadTimeout=20000 - How long should Scoop wait for the page to load, in ms?


### PR DESCRIPTION
- Check capture state while steps are running so they can be interrupted on the fly if necessary.
- New `--attachments-bypass-limits` option: Consolidated behind an option flag a behavior allowing attachments to skip time and size constraints.
- Moved _"Capture Page Info"_ earlier in the capture process.