### PR TITLE
Rework: non-web content detection and timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ const capture = await Scoop.capture(url, options)
 - [`Scoop.toWACZ()` method](https://github.com/harvard-lil/scoop/blob/main/Scoop.js#L1138)
 - [`Scoop.toWARC()` method](https://github.com/harvard-lil/scoop/blob/main/Scoop.js#L1126)
 - [`Scoop.fromWACZ()` method (experimental)](https://github.com/harvard-lil/scoop/blob/main/Scoop.js#L1117)
+- [Possible values of the `Scoop.state` property](https://github.com/harvard-lil/scoop/blob/main/Scoop.js#L45)
 
 
 ### Example: Capture with default settings


### PR DESCRIPTION
- Added `AbortController` for `Scoop.#detectAndCaptureNonWebContent()`
- Added handling of edge cases in `Scoop.capture()` (page automatically closing or staying on `about:blank` in very specific cases)
- Added `scoop.targetUrlIsWebPage` attribute
- Capture "teardown" step should only mark capture as `COMPLETE` if the previous state was `CAPTURE`