### PR TITLE
Feature: Capture certificates as attachment

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,18 @@ In practice, this most often means the bodies of HTTP exchanges are not included
 
 **Experimental:** WACZ files stored with the `includeRaw` option can be ingested by Scoop for analysis and processing via the `Scoop.fromWACZ()` method.
 
+### Should I run Scoop in headful mode?
+
+In certain cases, running Scoop in _"headful"_ mode might yield better results. 
+
+Passing `--headless false` to the CLI or `{ headless: false }` to the library will instruct **Scoop** to run **Chromium** in headful mode.
+
+Simulating a graphical output is necessary when running **Scoop** in headful mode on a server. The following command can be used for that purpose:
+
+```bash
+xvfb-run --auto-servernum -- scoop "https://lil.law.harvard.edu" --headless false
+```
+
 [👆 Back to the summary](#summary)
 
 ---

--- a/README.md
+++ b/README.md
@@ -164,42 +164,45 @@ Usage: scoop [options] <url>
 More info: https://github.com/harvard-lil/scoop
 
 Options:
-  -v, --version                                   Display Scoop and Scoop CLI version.
-  -o, --output <string>                           Output path. (default: "./archive.wacz")
-  -f, --format <string>                           Output format. (choices: "warc", "warc-gzipped", "wacz", "wacz-with-raw", default: "wacz")
-  --signing-url <string>                          Authsign-compatible endpoint for signing WACZ file.
-  --signing-token <string>                        Authentication token to --signing-url, if needed.
-  --screenshot <bool>                             Add screenshot step to capture? (choices: "true", "false", default: "true")
-  --pdf-snapshot <bool>                           Add PDF snapshot step to capture? (choices: "true", "false", default: "false")
-  --dom-snapshot <bool>                           Add DOM snapshot step to capture? (choices: "true", "false", default: "false")
-  --capture-video-as-attachment <bool>            Add capture video(s) as attachment(s) step to capture? (choices: "true", "false", default: "true")
-  --provenance-summary <bool>                     Add provenance summary to capture? (choices: "true", "false", default: "true")
-  --attachments-bypass-limits <bool>              If active, attachments will not count towards time and size constraints imposed on capture. (choices: "true", "false", default: "true")
-  --capture-timeout <number>                      Maximum time allocated to capture process before hard cut-off, in ms. (default: 60000)
-  --load-timeout <number>                         Max time Scoop will wait for the page to load, in ms. (default: 20000)
-  --network-idle-timeout <number>                 Max time Scoop will wait for the in-browser networking tasks to complete, in ms. (default: 20000)
-  --behaviors-timeout <number>                    Max time Scoop will wait for the browser behaviors to complete, in ms. (default: 20000)
-  --capture-video-as-attachment-timeout <number>  Max time Scoop will wait for the video capture process to complete, in ms. (default: 30000)
-  --capture-window-x <number>                     Width of the browser window Scoop will open to capture, in pixels. (default: 1600)
-  --capture-window-y <number>                     Height of the browser window Scoop will open to capture, in pixels. (default: 900)
-  --max-capture-size <number>                     Size limit for the capture's exchanges list, in bytes. (default: 209715200)
-  --auto-scroll <bool>                            Should Scoop try to scroll through the page? (choices: "true", "false", default: "true")
-  --auto-play-media <bool>                        Should Scoop try to autoplay `<audio>` and `<video>` tags? (choices: "true", "false", default: "true")
-  --grab-secondary-resources <bool>               Should Scoop try to download img srcsets and secondary stylesheets? (choices: "true", "false", default: "true")
-  --run-site-specific-behaviors <bool>            Should Scoop run site-specific capture behaviors? (via: browsertrix-behaviors) (choices: "true", "false", default: "true")
-  --headless <bool>                               Should Chrome run in headless mode? (choices: "true", "false", default: "true")
-  --user-agent-suffix <string>                    If provided, will be appended to Chrome's user agent. (default: "")
-  --blocklist <string>                            If set, replaces Scoop's default list of url patterns and IP ranges Scoop should not capture. Coma-separated. Example:
-                                                  "/https?://localhost/,0.0.0.0/8,10.0.0.0".
-  --intercepter <string>                          ScoopIntercepter class to be used to intercept network exchanges. (default: "ScoopProxy")
-  --proxy-host <string>                           Hostname to be used by Scoop's HTTP proxy. (default: "localhost")
-  --proxy-port <string>                           Port to be used by Scoop's HTTP proxy. (default: 9000)
-  --proxy-verbose <bool>                          Should Scoop's HTTP proxy output logs to the console? (choices: "true", "false", default: "false")
-  --public-ip-resolver-endpoint <string>          API endpoint to be used to resolve the client's IP address. Used in the context of the provenance summary. (default:
-                                                  "https://icanhazip.com")
-  --yt-dlp-path <string>                          Path to the yt-dlp executable. Used for capturing videos. (default: "[library]/executables/yt-dlp")
-  --log-level <string>                            Controls Scoop CLI's verbosity. (choices: "silent", "trace", "debug", "info", "warn", "error", default: "info")
-  -h, --help                                      Show options list.
+  -v, --version                                          Display Scoop and Scoop CLI version.
+  -o, --output <string>                                  Output path. (default: "./archive.wacz")
+  -f, --format <string>                                  Output format. (choices: "warc", "warc-gzipped", "wacz", "wacz-with-raw", default: "wacz")
+  --signing-url <string>                                 Authsign-compatible endpoint for signing WACZ file.
+  --signing-token <string>                               Authentication token to --signing-url, if needed.
+  --screenshot <bool>                                    Add screenshot step to capture? (choices: "true", "false", default: "true")
+  --pdf-snapshot <bool>                                  Add PDF snapshot step to capture? (choices: "true", "false", default: "false")
+  --dom-snapshot <bool>                                  Add DOM snapshot step to capture? (choices: "true", "false", default: "false")
+  --capture-video-as-attachment <bool>                   Add capture video(s) as attachment(s) step to capture? (choices: "true", "false", default: "true")
+  --capture-certificates-as-attachment <bool>            Add capture certificate(s) as attachment(s) step to capture? (choices: "true", "false", default: "true")
+  --provenance-summary <bool>                            Add provenance summary to capture? (choices: "true", "false", default: "true")
+  --attachments-bypass-limits <bool>                     If active, attachments will not count towards time and size constraints imposed on capture (--capture-timeout, --max--capture-size).
+                                                         (choices: "true", "false", default: "true")
+  --capture-timeout <number>                             Maximum time allocated to capture process before hard cut-off, in ms. (default: 60000)
+  --load-timeout <number>                                Max time Scoop will wait for the page to load, in ms. (default: 20000)
+  --network-idle-timeout <number>                        Max time Scoop will wait for the in-browser networking tasks to complete, in ms. (default: 20000)
+  --behaviors-timeout <number>                           Max time Scoop will wait for the browser behaviors to complete, in ms. (default: 20000)
+  --capture-video-as-attachment-timeout <number>         Max time Scoop will wait for the video capture process to complete, in ms. (default: 30000)
+  --capture-certificates-as-attachment-timeout <number>  Max time Scoop will wait for the certificates capture process to complete, in ms. (default: 10000)
+  --capture-window-x <number>                            Width of the browser window Scoop will open to capture, in pixels. (default: 1600)
+  --capture-window-y <number>                            Height of the browser window Scoop will open to capture, in pixels. (default: 900)
+  --max-capture-size <number>                            Size limit for the capture's exchanges list, in bytes. (default: 209715200)
+  --auto-scroll <bool>                                   Should Scoop try to scroll through the page? (choices: "true", "false", default: "true")
+  --auto-play-media <bool>                               Should Scoop try to autoplay `<audio>` and `<video>` tags? (choices: "true", "false", default: "true")
+  --grab-secondary-resources <bool>                      Should Scoop try to download img srcsets and secondary stylesheets? (choices: "true", "false", default: "true")
+  --run-site-specific-behaviors <bool>                   Should Scoop run site-specific capture behaviors? (via: browsertrix-behaviors) (choices: "true", "false", default: "true")
+  --headless <bool>                                      Should Chrome run in headless mode? (choices: "true", "false", default: "true")
+  --user-agent-suffix <string>                           If provided, will be appended to Chrome's user agent. (default: "")
+  --blocklist <string>                                   If set, replaces Scoop's default list of url patterns and IP ranges Scoop should not capture. Coma-separated. Example:
+                                                         "/https?://localhost/,0.0.0.0/8,10.0.0.0".
+  --intercepter <string>                                 ScoopIntercepter class to be used to intercept network exchanges. (default: "ScoopProxy")
+  --proxy-host <string>                                  Hostname to be used by Scoop's HTTP proxy. (default: "localhost")
+  --proxy-port <string>                                  Port to be used by Scoop's HTTP proxy. (default: 9000)
+  --proxy-verbose <bool>                                 Should Scoop's HTTP proxy output logs to the console? (choices: "true", "false", default: "false")
+  --public-ip-resolver-endpoint <string>                 API endpoint to be used to resolve the client's IP address. Used in the context of the provenance summary. (default: "https://icanhazip.com")
+  --yt-dlp-path <string>                                 Path to the yt-dlp executable. Used for capturing videos. (default: "[library]/executables/yt-dlp")
+  --crip-path <string>                                   Path to the crip executable. Used for capturing SSL/TLS certificates. (default: "[library]/executables/crip")
+  --log-level <string>                                   Controls Scoop CLI's verbosity. (choices: "silent", "trace", "debug", "info", "warn", "error", default: "info")
+  -h, --help                                             Show options list.
 ```
 </details>
 

--- a/Scoop.js
+++ b/Scoop.js
@@ -1025,7 +1025,7 @@ export class Scoop {
     // Start timeout timer
     //
     let timeIsOut = false
-    const timer = setTimeout(() => timeIsOut = true, captureCertificatesAsAttachmentTimeout)
+    const timer = setTimeout(() => { timeIsOut = true }, captureCertificatesAsAttachmentTimeout)
 
     //
     // Check that `crip` is available

--- a/assets/templates/provenance-summary.njk
+++ b/assets/templates/provenance-summary.njk
@@ -116,6 +116,13 @@
             <td>{{ ytDlpHash }}</td>
           </tr>
           {% endif %}
+
+          {% if cripHash %}
+          <tr>
+            <td>cripPath (redacted)<br>Replaced by executable checksum</td>
+            <td>{{ cripHash }}</td>
+          </tr>
+          {% endif %}
         </table>
       </section>
 
@@ -156,6 +163,19 @@
           <li>{{ url }}</li>
           {% endfor %}
         </ul>
+
+      </section>
+      {% endif %}
+
+      {% if certificates.length %}
+      <section>
+        <h2>SSL/TLS Certificates</h2>
+
+        <p>The following certificates were pulled by <em>crip</em> from the different origins encountered during capture.</p>
+
+        {% for cert in certificates %}
+        <li><a href="{{cert.host}}.pem">{{ cert.host }}</a></li>
+        {% endfor %}
 
       </section>
       {% endif %}

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -79,6 +79,12 @@ program.addOption(
 )
 
 program.addOption(
+  new Option('--capture-certificates-as-attachment <bool>', 'Add capture certificate(s) as attachment(s) step to capture?')
+    .choices(['true', 'false'])
+    .default(String(defaults.captureCertificatesAsAttachment))
+)
+
+program.addOption(
   new Option('--provenance-summary <bool>', 'Add provenance summary to capture?')
     .choices(['true', 'false'])
     .default(String(defaults.captureVideoAsAttachment))
@@ -126,6 +132,13 @@ program.addOption(
     '--capture-video-as-attachment-timeout <number>',
     'Max time Scoop will wait for the video capture process to complete, in ms.')
     .default(defaults.captureVideoAsAttachmentTimeout)
+)
+
+program.addOption(
+  new Option(
+    '--capture-certificates-as-attachment-timeout <number>',
+    'Max time Scoop will wait for the certificates capture process to complete, in ms.')
+    .default(defaults.captureCertificatesAsAttachmentTimeout)
 )
 
 //

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -265,6 +265,13 @@ program.addOption(
 )
 
 program.addOption(
+  new Option(
+    '--crip-path <string>',
+    'Path to the crip executable. Used for capturing SSL/TLS certificates.')
+    .default(defaults.cripPath)
+)
+
+program.addOption(
   new Option('--log-level <string>', 'Controls Scoop CLI\'s verbosity.')
     .choices(['silent', 'trace', 'debug', 'info', 'warn', 'error'])
     .default(defaults.logLevel)

--- a/exporters/scoopToWARC.js
+++ b/exporters/scoopToWARC.js
@@ -1,5 +1,4 @@
 import crypto from 'crypto'
-import { Blob } from 'buffer'
 
 import { WARCRecord, WARCSerializer } from 'warcio'
 

--- a/exporters/scoopToWARC.js
+++ b/exporters/scoopToWARC.js
@@ -21,7 +21,7 @@ if (!globalThis.crypto) {
  *
  * @param {Scoop} capture
  * @param {boolean} [gzip=false]
- * @returns {Promise<ArrayBuffer>}
+ * @returns {Promise<ArrayBuffer|Uint8Array>}
  */
 export async function scoopToWARC (capture, gzip = false) {
   let serializedInfo = null
@@ -107,7 +107,29 @@ export async function scoopToWARC (capture, gzip = false) {
   }
 
   //
-  // Combine output and return as ArrayBuffer
+  // Combine output and return as Uint8Array
   //
-  return new Blob([serializedInfo, ...serializedRecords]).arrayBuffer()
+
+  // Calculate total byte length
+  let totalByteLength = serializedInfo.length
+
+  for (const record of serializedRecords) {
+    totalByteLength += record.length
+  }
+
+  // Add entries
+  const warc = new Uint8Array(totalByteLength)
+
+  warc.set(serializedInfo, 0)
+
+  let offset = serializedInfo.length
+  for (const record of serializedRecords) {
+    warc.set(record, offset)
+    offset += record.length
+  }
+
+  return warc
+
+  // TODO: Investigate why this no longer works in latest Node 19.X.
+  // return new Blob([serializedInfo, ...serializedRecords]).arrayBuffer()
 }

--- a/options.js
+++ b/options.js
@@ -71,7 +71,8 @@ export const defaults = {
   proxyVerbose: false,
 
   publicIpResolverEndpoint: 'https://icanhazip.com',
-  ytDlpPath: `${CONSTANTS.EXECUTABLES_PATH}yt-dlp`
+  ytDlpPath: `${CONSTANTS.EXECUTABLES_PATH}yt-dlp`,
+  cripPath: `${CONSTANTS.EXECUTABLES_PATH}crip`
 }
 
 /**
@@ -130,8 +131,10 @@ export function filterOptions (newOptions = {}) {
   }
 
   // Check that paths are valid
-  if (!statSync(options.ytDlpPath).isFile()) {
-    throw new Error('"ytDlpPath" must be a path to a file.')
+  for (const toCheck of ['ytDlpPath', 'cripPath']) {
+    if (!statSync(options[toCheck]).isFile()) {
+      throw new Error(`"${toCheck}" must be a path to a file.`)
+    }
   }
 
   return options

--- a/options.js
+++ b/options.js
@@ -11,6 +11,7 @@ export const defaults = {
   pdfSnapshot: false,
   domSnapshot: false,
   captureVideoAsAttachment: true,
+  captureCertificatesAsAttachment: true,
   provenanceSummary: true,
   attachmentsBypassLimits: true,
 
@@ -19,6 +20,7 @@ export const defaults = {
   networkIdleTimeout: 20 * 1000,
   behaviorsTimeout: 20 * 1000,
   captureVideoAsAttachmentTimeout: 30 * 1000,
+  captureCertificatesAsAttachmentTimeout: 10 * 1000,
 
   captureWindowX: 1600,
   captureWindowY: 900,

--- a/options.types.js
+++ b/options.types.js
@@ -6,15 +6,17 @@
  * @property {boolean} screenshot=true - Should Scoop try to make a screenshot? Screenshot will be added as `file:///screenshot.png` in the exchanges list.
  * @property {boolean} pdfSnapshot=false - Should Scoop save a PDF of the rendered page? Only available in headless mode. Added as `file:///pdf-snapshot.pdf` in the exchanges list.
  * @property {boolean} domSnapshot=false - Should Scoop save a snapshot of the rendered DOM? Added as `file:///dom-snapshot.html` in the exchanges list.
- * @property {boolean} captureVideoAsAttachment=true - Should Scoop try to sae the main video(s) present on this page? Added as `file://` attachments, summarized under `file:///video-extracted-summary.html`. This capture happens out of the browser.
+ * @property {boolean} captureVideoAsAttachment=true - Should Scoop try to save the main video(s) present on this page? Added as `file://` attachments, summarized under `file:///video-extracted-summary.html`. This capture happens out of the browser.
+ * @property {boolean} captureCertificatesAsAttachment=true - Should Scoop try to capture and save the SSL/TLS certificates for the different origins encountered during capture?. This capture happens out of the browser.
  * @property {boolean} provenanceSummary=true - If `true`, information about the capture process (public IP address, User Agent, software version ...) will be gathered and summarized under `file:///provenance-summary.html`. WACZ exports will also hold that information at `datapackage.json` level, under `extras`.
- * @property {boolean} attachmentsBypassLimits=true - If `true`, "attachments" will not count towards the time and size constraints imposed on capture (captureTimeout, maxCaptureSize).
+ * @property {boolean} attachmentsBypassLimits=true - If `true`, "attachments" will not count towards the time and size constraints imposed on the capture itself (captureTimeout, maxCaptureSize).
  *
  * @property {number} captureTimeout=60000 - How long should Scoop wait for all steps in the capture to complete, in ms?
  * @property {number} loadTimeout=20000 - How long should Scoop wait for the page to load, in ms?
  * @property {number} networkIdleTimeout=20000 - How long should Scoop wait for network events to complete, in ms.
  * @property {number} behaviorsTimeout=20000 - How long should Scoop wait for media to play, secondary resources, and site specific behaviors (in total), in ms?
  * @property {number} captureVideoAsAttachmentTimeout=30000 - How long should Scoop wait for `captureVideoAsAttachment` to finish.
+ * @property {number} captureCertificatesAsAttachmentTimeout=10000 - How long should Scoop wait for `captureCertificatesAsAttachment` to finish.
  *
  * @property {number} captureWindowX=1600 - Browser window resolution in pixels: X axis.
  * @property {number} captureWindowY=900 - Browser window resolution in pixels: Y axis.

--- a/options.types.js
+++ b/options.types.js
@@ -36,5 +36,6 @@
  * @property {boolean} proxyVerbose=false - Should log entries from the proxy be printed?
  *
  * @property {string} publicIpResolverEndpoint="https://icanhazip.com" - URL to be used to retrieve the client's public IP address for `provenanceSummary`. Endpoint requirements: must simply return a IPv4 or IPv6 address as text.
- * @property {string} ytDlpPath="./executables/yt-dlp" - Path to the yt-dlp executable to be used.
+ * @property {string} ytDlpPath="./executables/yt-dlp" - Path to the yt-dlp executable to be used. (https://github.com/yt-dlp/yt-dlp)
+ * @property {string} cripPath="./executables/crip" - Path to the crip executable to be used. (https://github.com/Hakky54/certificate-ripper)
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harvard-lil/scoop",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@harvard-lil/scoop",
-      "version": "0.0.7",
+      "version": "0.1.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harvard-lil/scoop",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "description": "🍨 High-fidelity, browser-based, single-page web archiving library and CLI.",
   "main": "Scoop.js",
   "type": "module",

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -1,7 +1,21 @@
 #-------------------------------------------------------------------------------
 # Post-install script
 #-------------------------------------------------------------------------------
-# Pull yt-dlp (2023.03.04 version)
 mkdir ./executables/;
+
+# Pull yt-dlp (v2023.03.04)
 curl -L https://github.com/yt-dlp/yt-dlp/releases/download/2023.03.04/yt-dlp > ./executables/yt-dlp;
 chmod a+x ./executables/yt-dlp;
+
+# Pull crip (v2.1.0)
+if [ "$(uname)" == "Darwin" ]; then
+    curl -L https://github.com/Hakky54/certificate-ripper/releases/download/2.1.0/crip-macos-amd64.tar.gz > ./executables/crip.tar.gz;
+elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+    curl -L https://github.com/Hakky54/certificate-ripper/releases/download/2.1.0/crip-linux-amd64.tar.gz > ./executables/crip.tar.gz;
+fi
+
+cd ./executables;
+tar -xzvf crip.tar.gz;
+chmod a+x crip;
+rm crip.tar.gz;
+cd ..;


### PR DESCRIPTION
- Added an option to capture SSL/TLS certificates as attachments using `crip`, out of band. At this stage, it is _not_ running behind our proxy for practical reasons. 
- Fixes a compatibility bug with the latest version of Node.js 19.X. The following no longer works:
```javascript
return new Blob([serializedInfo, ...serializedRecords]).arrayBuffer()
```
- Version bump