### PR TITLE
Capture process tweaks

### DIFF
--- a/Scoop.js
+++ b/Scoop.js
@@ -765,7 +765,7 @@ export class Scoop {
           '--max-time', 1000
         ]
 
-        await exec('curl', curlOptions)
+        await exec('curl', curlOptions, { timeout: 1000 })
       } catch (err) {
         this.log.warn(`Could not fetch favicon at url ${this.pageInfo.faviconUrl}.`)
         this.log.trace(err)

--- a/Scoop.js
+++ b/Scoop.js
@@ -969,7 +969,6 @@ export class Scoop {
 
   /**
    * Tries to generate a PDF snapshot from Playwright and add it as a generated exchange (`file:///pdf-snapshot.pdf`).
-   * If `ghostscript` is available, will try to compress the resulting PDF.
    * Dimensions of the PDF are based on current document width and height.
    *
    * @param {Page} page - A Playwright [Page]{@link https://playwright.dev/docs/api/class-page} object

--- a/Scoop.test.js
+++ b/Scoop.test.js
@@ -125,7 +125,7 @@ await test('Scoop - capture of a non-web resource.', async (t) => {
   })
 
   await t.test('Scoop out-of-browser capture accounts for captureTimeout', async (_t) => {
-    const { exchanges: [html] } = await Scoop.capture(`${URL}/test.pdf`, { ...options, captureTimeout: 100 })
+    const { exchanges: [html] } = await Scoop.capture(`${URL}/test.pdf`, { ...options, captureTimeout: 10 })
     assert.equal(html, undefined) // Scoop's intercepter shouldn't have had time to boot up
     // assert.notEqual(html.response.body.byteLength, testPdfFixture.byteLength)
     // assert.notEqual(html.response.body, testPdfFixture)

--- a/exchanges/ScoopProxyExchange.js
+++ b/exchanges/ScoopProxyExchange.js
@@ -30,7 +30,7 @@ export class ScoopProxyExchange extends ScoopExchange {
   }
 
   get url () {
-    if (!this._url) {
+    if (!this._url && this.request) {
       this._url = this.request.startLine.split(' ')[1]
       if (this._url[0] === '/') {
         this._url = `https://${this.request.headers.get('host')}${this._url}`

--- a/exporters/scoopToWACZ.test.js
+++ b/exporters/scoopToWACZ.test.js
@@ -69,8 +69,11 @@ test('scoopToWACZ accounts for "signingServer" option appropriately.', async (t)
   const capture = await testCapture()
 
   const signingServer = {
-    url: process.env.TEST_WACZ_SIGNING_URL,
-    token: process.env?.TEST_WACZ_SIGNING_TOKEN
+    url: process.env.TEST_WACZ_SIGNING_URL
+  }
+
+  if (process.env.TEST_WACZ_SIGNING_TOKEN) {
+    signingServer.token = process.env.TEST_WACZ_SIGNING_TOKEN
   }
 
   // Load "datapackage-digest.json" to check that it contains a signature.

--- a/exporters/scoopToWACZ.test.js
+++ b/exporters/scoopToWACZ.test.js
@@ -61,7 +61,7 @@ test('scoopToWACZ accounts for "includeRaw" option appropriately.', async (_t) =
 
 test('scoopToWACZ accounts for "signingServer" option appropriately.', async (t) => {
   // This test only runs if credentials to a signing server are provided.
-  if (!process.env?.TEST_WACZ_SIGNING_TOKEN) {
+  if (!process.env?.TEST_WACZ_SIGNING_URL) {
     t.skip('No TEST_WACZ_SIGNING_URL env var present.')
     return
   }

--- a/intercepters/ScoopIntercepter.js
+++ b/intercepters/ScoopIntercepter.js
@@ -73,7 +73,7 @@ export class ScoopIntercepter {
   /**
    * Needs to be implemented by inheriting class.
    */
-  teardown () {
+  async teardown () {
     throw new Error('Method must be implemented.')
   }
 

--- a/intercepters/ScoopIntercepter.js
+++ b/intercepters/ScoopIntercepter.js
@@ -66,7 +66,7 @@ export class ScoopIntercepter {
    * Needs to be implemented by inheriting class.
    * @param {*} _page
    */
-  setup (_page) {
+  async setup (_page) {
     throw new Error('Method must be implemented.')
   }
 

--- a/intercepters/ScoopIntercepter.test.js
+++ b/intercepters/ScoopIntercepter.test.js
@@ -15,8 +15,8 @@ test('ScoopIntercepter constructor "capture" argument must be a Scoop instance.'
 test('ScoopIntercepter setup and teardown methods throw as not implemented.', async (_t) => {
   const capture = new Scoop('https://example.com')
   const intercepter = new ScoopIntercepter(capture)
-  assert.throws(() => intercepter.setup())
-  assert.throws(() => intercepter.teardown())
+  assert.rejects(intercepter.setup())
+  assert.rejects(intercepter.teardown())
 })
 
 test('checkExchangeForNoArchive returns true when noarchive directive is present in exchange.', async (_t) => {

--- a/intercepters/ScoopProxy.js
+++ b/intercepters/ScoopProxy.js
@@ -41,10 +41,12 @@ export class ScoopProxy extends ScoopIntercepter {
 
   /**
    * Closes the proxy server
-   * @returns {void}
+   * @returns {Primise<void>}
    */
-  teardown () {
+  async teardown () {
     this.#connection.close()
+    this.#connection.unref()
+    return true
   }
 
   /**

--- a/intercepters/ScoopProxy.js
+++ b/intercepters/ScoopProxy.js
@@ -41,7 +41,7 @@ export class ScoopProxy extends ScoopIntercepter {
 
   /**
    * Closes the proxy server
-   * @returns {Primise<void>}
+   * @returns {Promise<void>}
    */
   async teardown () {
     this.#connection.close()


### PR DESCRIPTION
- Moved `Scoop.setup()` and `Scoop.teardown()` out of the capture steps loop
- Enforce timeout on `curl` calls