### PR TITLE
(Tentative) Move SSL capture to ScoopProxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,6 @@ Options:
   --network-idle-timeout <number>                        Max time Scoop will wait for the in-browser networking tasks to complete, in ms. (default: 20000)
   --behaviors-timeout <number>                           Max time Scoop will wait for the browser behaviors to complete, in ms. (default: 20000)
   --capture-video-as-attachment-timeout <number>         Max time Scoop will wait for the video capture process to complete, in ms. (default: 30000)
-  --capture-certificates-as-attachment-timeout <number>  Max time Scoop will wait for the certificates capture process to complete, in ms. (default: 10000)
   --capture-window-x <number>                            Width of the browser window Scoop will open to capture, in pixels. (default: 1600)
   --capture-window-y <number>                            Height of the browser window Scoop will open to capture, in pixels. (default: 900)
   --max-capture-size <number>                            Size limit for the capture's exchanges list, in bytes. (default: 209715200)
@@ -201,7 +200,6 @@ Options:
   --proxy-verbose <bool>                                 Should Scoop's HTTP proxy output logs to the console? (choices: "true", "false", default: "false")
   --public-ip-resolver-endpoint <string>                 API endpoint to be used to resolve the client's IP address. Used in the context of the provenance summary. (default: "https://icanhazip.com")
   --yt-dlp-path <string>                                 Path to the yt-dlp executable. Used for capturing videos. (default: "[library]/executables/yt-dlp")
-  --crip-path <string>                                   Path to the crip executable. Used for capturing SSL/TLS certificates. (default: "[library]/executables/crip")
   --log-level <string>                                   Controls Scoop CLI's verbosity. (choices: "silent", "trace", "debug", "info", "warn", "error", default: "info")
   -h, --help                                             Show options list.
 ```
@@ -362,7 +360,7 @@ Namely:
 - Same goes for certificates, captured as attachments via [crip](https://github.com/Hakky54/certificate-ripper).
 - Favicons may be captured out-of-band using [curl](https://curl.se/), if not intercepted during capture.
 
-Exchanges captured in that context still go through Scoop's HTTP proxy, with the exception of _crip_.
+Exchanges captured in that context still go through Scoop's HTTP proxy.
 
 ```mermaid
 flowchart LR

--- a/Scoop.test.js
+++ b/Scoop.test.js
@@ -7,10 +7,10 @@ import express from 'express'
 import { FIXTURES_PATH } from './constants.js'
 import { isPNG, getDimensions } from './utils/png.js'
 import { isPDF, getPageCount } from './utils/pdf.js'
-import { defaults } from './options.js'
+import { defaults, testDefaults } from './options.js'
 import { Scoop } from './Scoop.js'
 
-await test('Scoop - capture of a web page.', async (t) => {
+await test('Scoop - capture of a (local) web page.', async (t) => {
   const app = express()
   const PORT = 3000
   const URL = `http://localhost:${PORT}`
@@ -103,7 +103,16 @@ await test('Scoop - capture of a web page.', async (t) => {
   server.close()
 })
 
-await test('Scoop - capture of a non-web resource.', async (t) => {
+// Accounts for tests that can't be run locally
+await test('Scoop - capture of a (remote) web page.', async (t) => {
+  await t.test('Scoop captures SSL certificates', async (_t) => {
+    const capture = await Scoop.capture('https://example.com', testDefaults)
+    assert(capture.provenanceInfo.certificates['example.com'])
+    assert(capture.extractGeneratedExchanges()['example.com.pem'])
+  })
+})
+
+await test('Scoop - capture of a (local) non-web resource.', async (t) => {
   const app = express()
   const PORT = 3000
   const URL = `http://localhost:${PORT}`

--- a/assets/templates/provenance-summary.njk
+++ b/assets/templates/provenance-summary.njk
@@ -165,14 +165,14 @@
       </section>
       {% endif %}
 
-      {% if certificates.length %}
+      {% if certificates|length %}
       <section>
         <h2>SSL/TLS Certificates</h2>
 
         <p>The following certificates were pulled by <em>crip</em> from the different origins encountered during capture.</p>
 
-        {% for cert in certificates %}
-        <li><a href="{{cert.host}}.pem">{{ cert.host }}</a></li>
+        {% for host, pem in certificates %}
+        <li><a href="{{host}}.pem">{{ host }}</a></li>
         {% endfor %}
 
       </section>

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -140,13 +140,6 @@ program.addOption(
     .default(defaults.captureVideoAsAttachmentTimeout)
 )
 
-program.addOption(
-  new Option(
-    '--capture-certificates-as-attachment-timeout <number>',
-    'Max time Scoop will wait for the certificates capture process to complete, in ms.')
-    .default(defaults.captureCertificatesAsAttachmentTimeout)
-)
-
 //
 // Dimensions
 //
@@ -281,13 +274,6 @@ program.addOption(
     '--yt-dlp-path <string>',
     'Path to the yt-dlp executable. Used for capturing videos.')
     .default(defaults.ytDlpPath)
-)
-
-program.addOption(
-  new Option(
-    '--crip-path <string>',
-    'Path to the crip executable. Used for capturing SSL/TLS certificates.')
-    .default(defaults.cripPath)
 )
 
 program.addOption(

--- a/intercepters/ScoopProxy.js
+++ b/intercepters/ScoopProxy.js
@@ -139,6 +139,7 @@ export class ScoopProxy extends ScoopIntercepter {
   onConnected (serverSocket, request) {
     const ip = serverSocket.remoteAddress
     const rule = this.findMatchingBlocklistRule(ip)
+
     if (rule) {
       serverSocket.destroy()
       this.blockRequest(request, ip, rule)
@@ -147,17 +148,67 @@ export class ScoopProxy extends ScoopIntercepter {
 
   /**
    * On response:
+   * - Capture cert if relevant option is on, cert is available, and not already captured for this host
    * - Check for "noarchive" directive
+   *
    * @param {http.ServerResponse} response
    * @param {http.ClientRequest} request
    */
   onResponse (response, request) {
-    // there will not be an exchange with this request if we're, for instance, not recording
+    // There will not be an exchange with this request if we're, for instance, not recording
     const exchange = this.exchanges.find(ex => ex.requestParsed === request)
 
+    // Copy response, check for no-archive directive
     if (exchange) {
       exchange.responseParsed = response
       response.on('end', () => this.checkExchangeForNoArchive(exchange))
+    }
+
+    // Capture SSL cert
+    if (exchange && response.socket) {
+      const { provenanceInfo, options } = this.capture
+      const host = new URL(exchange.url).host
+
+      if (!response.socket.getPeerCertificate ||
+          !options.captureCertificatesAsAttachment ||
+          provenanceInfo.certificates[host]) {
+        return
+      }
+
+      let cert = response.socket.getPeerCertificate(true)
+      let pem = ''
+      let lastRawCert = null
+
+      // Go through the certificate chain using its recursive `issuerCertificate` property to assemble the .pem file.
+      while (cert && cert?.raw && cert.raw.length > 0) {
+        // In some cases, "issuerCertificate" recurses infinitely.
+        // This breaker accounts for that edge case.
+        if (lastRawCert === cert.raw) {
+          break
+        }
+
+        const certAsBase64 = cert.raw.toString('base64')
+
+        pem += '-----BEGIN CERTIFICATE-----\n'
+        for (let i = 0; i < certAsBase64.length; i += 64) {
+          pem += certAsBase64.slice(i, i + 64)
+          pem += '\n'
+        }
+        pem += '-----END CERTIFICATE-----\n'
+
+        lastRawCert = cert.raw
+        cert = cert?.issuerCertificate
+      }
+
+      if (!pem) {
+        return
+      }
+
+      this.capture.addCertificate(host, pem)
+        .catch(err => {
+          this.capture.log.trace(err)
+          this.capture.log.warn(`An error occurred while capturing certificate for "${host}".`)
+        })
     }
   }
 

--- a/options.js
+++ b/options.js
@@ -20,7 +20,6 @@ export const defaults = {
   networkIdleTimeout: 20 * 1000,
   behaviorsTimeout: 20 * 1000,
   captureVideoAsAttachmentTimeout: 30 * 1000,
-  captureCertificatesAsAttachmentTimeout: 10 * 1000,
 
   captureWindowX: 1600,
   captureWindowY: 900,
@@ -73,8 +72,7 @@ export const defaults = {
   proxyVerbose: false,
 
   publicIpResolverEndpoint: 'https://icanhazip.com',
-  ytDlpPath: `${CONSTANTS.EXECUTABLES_PATH}yt-dlp`,
-  cripPath: `${CONSTANTS.EXECUTABLES_PATH}crip`
+  ytDlpPath: `${CONSTANTS.EXECUTABLES_PATH}yt-dlp`
 }
 
 /**
@@ -133,10 +131,8 @@ export function filterOptions (newOptions = {}) {
   }
 
   // Check that paths are valid
-  for (const toCheck of ['ytDlpPath', 'cripPath']) {
-    if (!statSync(options[toCheck]).isFile()) {
-      throw new Error(`"${toCheck}" must be a path to a file.`)
-    }
+  if (!statSync(options.ytDlpPath).isFile()) {
+    throw new Error('"ytDlpPath" must be a path to a file.')
   }
 
   return options

--- a/options.types.js
+++ b/options.types.js
@@ -16,7 +16,6 @@
  * @property {number} networkIdleTimeout=20000 - How long should Scoop wait for network events to complete, in ms.
  * @property {number} behaviorsTimeout=20000 - How long should Scoop wait for media to play, secondary resources, and site specific behaviors (in total), in ms?
  * @property {number} captureVideoAsAttachmentTimeout=30000 - How long should Scoop wait for `captureVideoAsAttachment` to finish.
- * @property {number} captureCertificatesAsAttachmentTimeout=10000 - How long should Scoop wait for `captureCertificatesAsAttachment` to finish.
  *
  * @property {number} captureWindowX=1600 - Browser window resolution in pixels: X axis.
  * @property {number} captureWindowY=900 - Browser window resolution in pixels: Y axis.
@@ -39,5 +38,4 @@
  *
  * @property {string} publicIpResolverEndpoint="https://icanhazip.com" - URL to be used to retrieve the client's public IP address for `provenanceSummary`. Endpoint requirements: must simply return a IPv4 or IPv6 address as text.
  * @property {string} ytDlpPath="./executables/yt-dlp" - Path to the yt-dlp executable to be used. (https://github.com/yt-dlp/yt-dlp)
- * @property {string} cripPath="./executables/crip" - Path to the crip executable to be used. (https://github.com/Hakky54/certificate-ripper)
  */

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -6,16 +6,3 @@ mkdir ./executables/;
 # Pull yt-dlp (v2023.03.04)
 curl -L https://github.com/yt-dlp/yt-dlp/releases/download/2023.03.04/yt-dlp > ./executables/yt-dlp;
 chmod a+x ./executables/yt-dlp;
-
-# Pull crip (v2.1.0)
-if [ "$(uname)" == "Darwin" ]; then
-    curl -L https://github.com/Hakky54/certificate-ripper/releases/download/2.1.0/crip-macos-amd64.tar.gz > ./executables/crip.tar.gz;
-elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-    curl -L https://github.com/Hakky54/certificate-ripper/releases/download/2.1.0/crip-linux-amd64.tar.gz > ./executables/crip.tar.gz;
-fi
-
-cd ./executables;
-tar -xzvf crip.tar.gz;
-chmod a+x crip;
-rm crip.tar.gz;
-cd ..;


### PR DESCRIPTION
Implements #138

---

- Removes `crip` dependency, dedicated certificates capture step, and associated options.
- Intercepts certificate chain at `ScoopProxy` level using `socket.getPeerCertificate()` to assemble a PEM on the fly. Runs once per origin.
- Removes duplicate processing of `noarchive` checks

---

**Still working through:** The certificates interception currently happens at `ScoopProxy.onResponse()` level. 
It should be in `ScoopProxy.onConnected()`, but in some cases it appears to be _"too early"_. 
TBD, but this version works.