### PR TITLE
js-wacz-upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@harvard-lil/js-wacz": "^0.0.9",
-        "@harvard-lil/portal": "^0.0.1",
+        "@harvard-lil/js-wacz": "^0.0.10",
+        "@harvard-lil/portal": "^0.0.2",
         "@laverdet/beaugunderson-ip-address": "^8.1.0",
         "browsertrix-behaviors": "^0.5.0-beta.0",
         "chalk": "^5.2.0",
@@ -83,9 +83,9 @@
       "dev": true
     },
     "node_modules/@harvard-lil/js-wacz": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@harvard-lil/js-wacz/-/js-wacz-0.0.9.tgz",
-      "integrity": "sha512-A8Erbvw5EdAode/Zj/gFi1NsABpWrayv0CxZzRe0YUFHsmpxf5WUU1+4oYVx0UgFUw8ZaWl4WHyQzp/2/+bvrQ==",
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@harvard-lil/js-wacz/-/js-wacz-0.0.10.tgz",
+      "integrity": "sha512-s5R07CZ0One7D2vi12ETy+kMaoZ2rBfrWtFP1Z+Z7HImunkCZiblpfaBgLuJoLK6V27NLHEb51eaLSaKpBNLrA==",
       "dependencies": {
         "archiver": "^5.3.1",
         "chalk": "^5.2.0",
@@ -150,9 +150,9 @@
       "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
     },
     "node_modules/@harvard-lil/portal": {
-      "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/harvard-lil/portal.git#2693d528d62cd9fec85ba630a104e7a4ac311b43",
-      "license": "MIT",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@harvard-lil/portal/-/portal-0.0.2.tgz",
+      "integrity": "sha512-yFJFXdiZiZMdgu7H4lqArc2lolIJKkBUvIi2UUZVjgC4N5q+8d6ESMDPsdIjaVhmFuMEqGGA4WROE3m6r6Do2A==",
       "engines": {
         "node": ">=18.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
   },
   "homepage": "https://github.com/harvard-lil/scoop#readme",
   "dependencies": {
-    "@harvard-lil/js-wacz": "^0.0.9",
-    "@harvard-lil/portal": "^0.0.1",
+    "@harvard-lil/js-wacz": "^0.0.10",
+    "@harvard-lil/portal": "^0.0.2",
     "@laverdet/beaugunderson-ip-address": "^8.1.0",
     "browsertrix-behaviors": "^0.5.0-beta.0",
     "chalk": "^5.2.0",


### PR DESCRIPTION
- Upgrades [`js-wacz` to `0.0.10`](https://github.com/harvard-lil/js-wacz/releases/tag/0.0.10). This version produces simpler index files for small archives (simple index.cdx as opposed to Zip Num Shared Index), which is a particularly relevant optimization in the context of Scoop.
- Upgrades `portal` to `0.0.2`.