### PR TITLE
Error reporting bug fixes

### DIFF
--- a/Scoop.js
+++ b/Scoop.js
@@ -766,11 +766,22 @@ export class Scoop {
       }
     })
 
+    //
+    // Favicon processing
+    //
+
+    // Not needed if:
+    // - No favicon URL found
+    // - Favicon url is not an http(s) URL
     if (!this.pageInfo?.faviconUrl) {
       return
     }
 
-    // If `headless`: request the favicon using curl.
+    if (!this.pageInfo.faviconUrl.startsWith('http')) {
+      return
+    }
+
+    // If `headless`: request the favicon using curl so it's added to the exchanges list.
     if (this.options.headless) {
       try {
         const userAgent = await page.evaluate(() => window.navigator.userAgent) // Source user agent from the browser

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -387,7 +387,11 @@ program.action(async (name, options, command) => {
     url = command.processedArgs[0]
     capture = await Scoop.capture(url, options)
   } catch (err) {
-    process.exit(1) // Logs handled by Scoop
+    // Logs are handled by Scoop directly, unless `Scoop.capture` fails during initialization
+    if (!capture) {
+      console.error(err.message)
+    }
+    process.exit(1)
   }
 
   //


### PR DESCRIPTION
### Bug fixes:
- `Scoop.#capturePageInfo()`: Account for data URL favicons.
- **CLI:** In certain cases, invalid combinations of options would lead to the program exiting without printing an error message.