### PR TITLE
js-wacz upgrade

### DIFF
--- a/exporters/scoopToWARC.test.js
+++ b/exporters/scoopToWARC.test.js
@@ -61,7 +61,7 @@ test('scoopToWARC generates a valid WARC file.', async (_t) => {
   assert.equal(expectedResponses, actualResponses)
 })
 
-test('scoopToWARC\'s gzip option is property taken into account.', async (_t) => {
+test('scoopToWARC\'s gzip option is properly taken into account.', async (_t) => {
   const capture = await Scoop.fromWACZ(`${FIXTURES_PATH}example.com.wacz`)
 
   const raw = await scoopToWARC(capture, false)

--- a/exporters/scoopToWARC.test.js
+++ b/exporters/scoopToWARC.test.js
@@ -61,7 +61,7 @@ test('scoopToWARC generates a valid WARC file.', async (_t) => {
   assert.equal(expectedResponses, actualResponses)
 })
 
-test('gzip option is property taken into account.', async (_t) => {
+test('scoopToWARC\'s gzip option is property taken into account.', async (_t) => {
   const capture = await Scoop.fromWACZ(`${FIXTURES_PATH}example.com.wacz`)
 
   const raw = await scoopToWARC(capture, false)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@harvard-lil/js-wacz": "^0.0.10",
+        "@harvard-lil/js-wacz": "^0.0.11",
         "@harvard-lil/portal": "^0.0.2",
         "@laverdet/beaugunderson-ip-address": "^8.1.0",
         "browsertrix-behaviors": "^0.5.0-beta.0",
@@ -83,9 +83,9 @@
       "dev": true
     },
     "node_modules/@harvard-lil/js-wacz": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/@harvard-lil/js-wacz/-/js-wacz-0.0.10.tgz",
-      "integrity": "sha512-s5R07CZ0One7D2vi12ETy+kMaoZ2rBfrWtFP1Z+Z7HImunkCZiblpfaBgLuJoLK6V27NLHEb51eaLSaKpBNLrA==",
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/@harvard-lil/js-wacz/-/js-wacz-0.0.11.tgz",
+      "integrity": "sha512-l3xIX99h5CBPYp8kk0SybeJSDowPa7Tikc2hiVsEA5a6UAnyp0KmkUR2as/Byt6Lt6uLb1sFPFp2+LfKjewazw==",
       "dependencies": {
         "archiver": "^5.3.1",
         "chalk": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "homepage": "https://github.com/harvard-lil/scoop#readme",
   "dependencies": {
-    "@harvard-lil/js-wacz": "^0.0.10",
+    "@harvard-lil/js-wacz": "^0.0.11",
     "@harvard-lil/portal": "^0.0.2",
     "@laverdet/beaugunderson-ip-address": "^8.1.0",
     "browsertrix-behaviors": "^0.5.0-beta.0",


### PR DESCRIPTION
Upgrade to `js-wacz` 0.0.11, which includes a fix for the missing `profile` property of `datapackage.json`.