### PR TITLE
Add `--export-attachments-output` CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Options:
   -o, --output <string>                                  Output path. (default: "./archive.wacz")
   -f, --format <string>                                  Output format. (choices: "warc", "warc-gzipped", "wacz", "wacz-with-raw", default: "wacz")
   --json-summary-output <string>                         If set, allows for saving a capture summary as JSON. Must be a path to .json file.
+  --export-attachments-output <string>                   If set, allows for exporting attachments (screenshot, certs, ...). Must be a path to an existing directory.
   --signing-url <string>                                 Authsign-compatible endpoint for signing WACZ file.
   --signing-token <string>                               Authentication token to --signing-url, if needed.
   --screenshot <bool>                                    Add screenshot step to capture? (choices: "true", "false", default: "true")

--- a/Scoop.js
+++ b/Scoop.js
@@ -1235,7 +1235,6 @@ export class Scoop {
 
   /**
    * Generates a ScoopGeneratedExchange for generated content and adds it to `exchanges`.
-   * Unless `force` argument is passed, generated exchanges count towards time / size limits.
    *
    * @param {string} url
    * @param {Headers} headers

--- a/Scoop.js
+++ b/Scoop.js
@@ -1374,9 +1374,19 @@ export class Scoop {
    * @property {string} startedAt - ISO-formated date
    * @property {string[]} blockedRequests
    * @property {string[]} noArchiveUrls
-   * @property {string[]} exchangeUrls
    * @property {?string} captureIp
    * @property {?string} userAgent
+   * @property {string[]} exchangeUrls
+   * @property {object} attachments
+   * @property {?string} attachments.provenanceSummary - Filename
+   * @property {?string} attachments.screenshot - Filename
+   * @property {?string} attachments.pdfSnapshot - Filename
+   * @property {?string} attachments.domSnapshot - Filename
+   * @property {?string} attachments.videoExtractedSummary - Filename
+   * @property {?string} attachments.videoExtractedMetadata - Filename
+   * @property {?string[]} attachments.videoExtracted - Filenames
+   * @property {?string[]} attachments.videoExtractedSubtitles - Filenames
+   * @property {?string[]} attachments.certificates - Filenames
    */
 
   /**
@@ -1384,7 +1394,7 @@ export class Scoop {
    * @returns {Promise<ScoopCaptureSummary>}
    */
   async summary () {
-    return {
+    const summary = {
       state: this.state,
       states: Scoop.states,
       targetUrl: this.url,
@@ -1395,7 +1405,58 @@ export class Scoop {
       noArchiveUrls: [],
       captureIp: this.provenanceInfo?.captureIp,
       userAgent: this.provenanceInfo?.userAgent,
-      exchangeUrls: this.exchanges.map(exchange => exchange.url)
+      exchangeUrls: this.exchanges.map(exchange => exchange.url),
+      attachments: {}
     }
+
+    //
+    // Summarize attachments
+    //
+    const generatedExchanges = this.extractGeneratedExchanges()
+
+    // 1-to-1 matches:
+    // - Add filename to "attachments" as key if present in generated exchanges list
+    // - Example: attachments.provenanceSummary = "provenance-summary.html"
+    for (const [key, filename] of Object.entries({
+      provenanceSummary: 'provenance-summary.html',
+      screenshot: 'screenshot.png',
+      pdfSnapshot: 'pdf-snapshot.pdf',
+      domSnapshot: 'dom-snapshot.html',
+      videoExtractedSummary: 'video-extracted-summary.html',
+      videoExtractedMetadata: 'video-extracted-metadata.json'
+    })) {
+      if (generatedExchanges[filename]) {
+        summary.attachments[key] = filename
+      }
+    }
+
+    // 1-to-many matches:
+    // - Videos are added to attachments.videoExtracted[]
+    // - Video subtitles are added to attachments.videoSubtitles[]
+    // - SSL certs are added to attachments.certificates[]
+    for (const filename of Object.keys(generatedExchanges)) {
+      if (filename.endsWith('.mp4')) {
+        if (!summary.attachments?.videos) {
+          summary.attachments.videoExtracted = []
+        }
+        summary.attachments.videoExtracted.push(filename)
+      }
+
+      if (filename.endsWith('.vtt')) {
+        if (!summary.attachments?.videoSubtitles) {
+          summary.attachments.videoExtractedSubtitles = []
+        }
+        summary.attachments.videoExtractedSubtitles.push(filename)
+      }
+
+      if (filename.endsWith('.pem')) {
+        if (!summary.attachments?.certificates) {
+          summary.attachments.certificates = []
+        }
+        summary.attachments.certificates.push(filename)
+      }
+    }
+
+    return summary
   }
 }

--- a/Scoop.test.js
+++ b/Scoop.test.js
@@ -89,12 +89,13 @@ await test('Scoop - capture of a web page.', async (t) => {
   })
 
   await t.test('Scoop.summary() returns a valid object', async (_t) => {
-    const capture = await Scoop.capture(`${URL}/test.html`, options)
+    const capture = await Scoop.capture(`${URL}/test.html`, { ...options, provenanceSummary: true })
     const summary = await capture.summary()
     assert(summary)
     assert.equal(summary.targetUrl, capture.url)
     assert.equal(summary.state, Scoop.states.COMPLETE)
     assert.equal(summary.exchangeUrls.length, capture.exchanges.length)
+    assert.equal(summary.attachments.provenanceSummary, 'provenance-summary.html')
   })
 
   /*


### PR DESCRIPTION
This new option allows for exporting attachments (generated exchanges) to a given directory at the end of the capture process.