### PR TITLE
yt-dlp upgrade, non-web content detection tweak

### DIFF
--- a/Scoop.js
+++ b/Scoop.js
@@ -691,7 +691,7 @@ export class Scoop {
     }
 
     // If text/html or no content-type, bail from non-web content capture process.
-    // Scoop.capture will go based on the value of `this.targeredUrlIsWebPage`.
+    // Scoop.capture will go based on the value of `this.targetUrlIsWebPage`.
     if (!contentType) {
       this.log.info('Requested URL is assumed to be a web page (no content-type found)')
       return

--- a/Scoop.js
+++ b/Scoop.js
@@ -690,8 +690,13 @@ export class Scoop {
       this.targetUrlContentType = contentType
     }
 
-    // If text/html, bail from non-web content capture process.
+    // If text/html or no content-type, bail from non-web content capture process.
     // Scoop.capture will go based on the value of `this.targeredUrlIsWebPage`.
+    if (!contentType) {
+      this.log.info('Requested URL is assumed to be a web page (no content-type found)')
+      return
+    }
+
     if (contentType?.startsWith('text/html')) {
       this.log.info('Requested URL is a web page')
       return

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -4,7 +4,7 @@
 mkdir ./executables/;
 
 # Pull yt-dlp (v2023.03.04)
-curl -L https://github.com/yt-dlp/yt-dlp/releases/download/2023.03.04/yt-dlp > ./executables/yt-dlp;
+curl -L https://github.com/yt-dlp/yt-dlp/releases/download/2023.06.21/yt-dlp > ./executables/yt-dlp;
 chmod a+x ./executables/yt-dlp;
 
 # Pull crip (v2.1.0)


### PR DESCRIPTION
- Upgraded to [yt-dlp 2023.06.21](https://github.com/yt-dlp/yt-dlp/releases/tag/2023.06.21)
- Tweaked non-web content detection to account for absence of content-type (assume target url is web content in that case)