### PR TITLE
Downgrading to yt-dlp 2023.03.04

### DIFF
--- a/postinstall.sh
+++ b/postinstall.sh
@@ -4,7 +4,7 @@
 mkdir ./executables/;
 
 # Pull yt-dlp (v2023.03.04)
-curl -L https://github.com/yt-dlp/yt-dlp/releases/download/2023.06.21/yt-dlp > ./executables/yt-dlp;
+curl -L https://github.com/yt-dlp/yt-dlp/releases/download/2023.03.04/yt-dlp > ./executables/yt-dlp;
 chmod a+x ./executables/yt-dlp;
 
 # Pull crip (v2.1.0)


### PR DESCRIPTION
TBD - We've noticed poorer performance on key platforms with the latest version of yt-dlp and are considering downgrading to 2023.03.04 for the time being.