### PR TITLE
Upgrade to yt-dlp 2023.06.22

### DIFF
--- a/postinstall.sh
+++ b/postinstall.sh
@@ -3,8 +3,8 @@
 #-------------------------------------------------------------------------------
 mkdir ./executables/;
 
-# Pull yt-dlp (v2023.03.04)
-curl -L https://github.com/yt-dlp/yt-dlp/releases/download/2023.03.04/yt-dlp > ./executables/yt-dlp;
+# Pull yt-dlp (v2023.06.22)
+curl -L https://github.com/yt-dlp/yt-dlp/releases/download/2023.06.22/yt-dlp > ./executables/yt-dlp;
 chmod a+x ./executables/yt-dlp;
 
 # Pull crip (v2.1.0)


### PR DESCRIPTION
Changelog:
- https://github.com/yt-dlp/yt-dlp/releases/tag/2023.06.21
- https://github.com/yt-dlp/yt-dlp/releases/tag/2023.06.22

This latest version fixes the bug introduced in 2023.06.21 that prevented us from upgrading.