### PR TITLE
Remove partial support for the `noarchive` directive

### DIFF
--- a/Scoop.js
+++ b/Scoop.js
@@ -155,7 +155,6 @@ export class Scoop {
    *   osVersion: ?string,
    *   cpuArchitecture: ?string,
    *   blockedRequests: Array.<{match: string, rule: string}>,
-   *   noArchiveUrls: string[],
    *   certificates: Array.<{host: string, pem: string}>,
    *   ytDlpHash: string,
    *   cripHash: string,
@@ -164,7 +163,6 @@ export class Scoop {
    */
   provenanceInfo = {
     blockedRequests: [],
-    noArchiveUrls: [],
     certificates: []
   }
 

--- a/assets/templates/provenance-summary.njk
+++ b/assets/templates/provenance-summary.njk
@@ -150,21 +150,6 @@
       </section>
       {% endif %}
 
-      {% if noArchiveUrls.length %}
-      <section>
-        <h2>Urls tagged with the "noarchive" directive</h2>
-
-        <p>The following urls returned an HTML document tagged with the <em>noarchive</em> directive.</p>
-
-        <ul>
-          {% for url in noArchiveUrls %}
-          <li>{{ url }}</li>
-          {% endfor %}
-        </ul>
-
-      </section>
-      {% endif %}
-
       {% if certificates.length %}
       <section>
         <h2>SSL/TLS Certificates</h2>

--- a/intercepters/ScoopIntercepter.test.js
+++ b/intercepters/ScoopIntercepter.test.js
@@ -1,10 +1,8 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { FIXTURES_PATH } from '../constants.js'
 import { ScoopIntercepter } from './index.js'
 import { Scoop } from '../Scoop.js'
-import { ScoopProxyExchange } from '../exchanges/ScoopProxyExchange.js'
 
 test('ScoopIntercepter constructor "capture" argument must be a Scoop instance.', async (_t) => {
   for (const capture of [{}, [], true, 12, 'FOO', ['FOO'], () => {}]) {
@@ -17,36 +15,6 @@ test('ScoopIntercepter setup and teardown methods throw as not implemented.', as
   const intercepter = new ScoopIntercepter(capture)
   assert.rejects(intercepter.setup())
   assert.rejects(intercepter.teardown())
-})
-
-test('checkExchangeForNoArchive returns true when noarchive directive is present in exchange.', async (_t) => {
-  const capture = await Scoop.fromWACZ(`${FIXTURES_PATH}/noarchive.netlify.app.wacz`)
-  const intercepter = new ScoopIntercepter(capture)
-
-  // Exactly 1 ScoopProxyExchange in that capture bears the "noarchive" directive.
-  let noArchiveCount = 0
-
-  for (const exchange of capture.exchanges) {
-    if (exchange instanceof ScoopProxyExchange === false) {
-      continue
-    }
-
-    noArchiveCount += Number(await intercepter.checkExchangeForNoArchive(exchange))
-  }
-
-  assert.equal(noArchiveCount, 1)
-})
-
-test('checkExchangeForNoArchive returns false when noarchive directive is not present in exchange.', async (_t) => {
-  const capture = await Scoop.fromWACZ(`${FIXTURES_PATH}/example.com.wacz`)
-  const intercepter = new ScoopIntercepter(capture)
-
-  let noArchiveCount = 0
-  for (const exchange of capture.exchanges) {
-    noArchiveCount += Number(await intercepter.checkExchangeForNoArchive(exchange))
-  }
-
-  assert.equal(noArchiveCount, 0)
 })
 
 test('checkAndEnforceSizeLimit interrupts capture when size limit is reached.', async (_t) => {

--- a/intercepters/ScoopProxy.js
+++ b/intercepters/ScoopProxy.js
@@ -147,7 +147,7 @@ export class ScoopProxy extends ScoopIntercepter {
 
   /**
    * On response:
-   * - Check for "noarchive" directive
+   * - Parse response
    * @param {http.ServerResponse} response
    * @param {http.ClientRequest} request
    */
@@ -157,7 +157,6 @@ export class ScoopProxy extends ScoopIntercepter {
 
     if (exchange) {
       exchange.responseParsed = response
-      response.on('end', () => this.checkExchangeForNoArchive(exchange))
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "node-html-parser": "^6.1.4",
         "node-stream-zip": "^1.15.0",
         "nunjucks": "^3.2.3",
-        "playwright": "^1.36.2",
+        "playwright": "^1.37.0",
         "uuid": "^9.0.0",
         "warcio": "^2.1.0"
       },
@@ -3815,12 +3815,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.36.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.36.2.tgz",
-      "integrity": "sha512-4Fmlq3KWsl85Bl4InJw1NC21aeQV0iSZuFvTDcy1F8zVmXmgQRe89GxF8zMSRt/KIS+2tUolak7EXVl9aC+JdA==",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.37.0.tgz",
+      "integrity": "sha512-CrAEFfVioamMwDKmygc/HAkzEAxYAwjD+zod2poTxM7ObivkoDsKHu1ned16fnQV/Tf1kDB8KtsyH8Qd3VzJIg==",
       "hasInstallScript": true,
       "dependencies": {
-        "playwright-core": "1.36.2"
+        "playwright-core": "1.37.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -3830,9 +3830,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.36.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.36.2.tgz",
-      "integrity": "sha512-sQYZt31dwkqxOrP7xy2ggDfEzUxM1lodjhsQ3NMMv5uGTRDsLxU0e4xf4wwMkF2gplIxf17QMBCodSFgm6bFVQ==",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.37.0.tgz",
+      "integrity": "sha512-1c46jhTH/myQw6sesrcuHVtLoSNfJv8Pfy9t3rs6subY7kARv0HRw5PpyfPYPpPtQvBOmgbE6K+qgYUpj81LAA==",
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "get-os-info": "^1.0.2",
         "loglevel": "^1.8.1",
         "loglevel-plugin-prefix": "^0.8.4",
-        "node-html-parser": "^6.1.4",
         "node-stream-zip": "^1.15.0",
         "nunjucks": "^3.2.3",
         "playwright": "^1.37.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "get-os-info": "^1.0.2",
     "loglevel": "^1.8.1",
     "loglevel-plugin-prefix": "^0.8.4",
-    "node-html-parser": "^6.1.4",
     "node-stream-zip": "^1.15.0",
     "nunjucks": "^3.2.3",
     "playwright": "^1.37.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "node-html-parser": "^6.1.4",
     "node-stream-zip": "^1.15.0",
     "nunjucks": "^3.2.3",
-    "playwright": "^1.36.2",
+    "playwright": "^1.37.0",
     "uuid": "^9.0.0",
     "warcio": "^2.1.0"
   },


### PR DESCRIPTION
## About this PR 

The first versions of Scoop shipped with _partial_ support for the detection of the `noarchive` directive, inspecting HTTP responses to find `<meta>` tags containing `noarchive`, and listing _"positive"_ URLs both in the logs and in the provenance summary.

This implementation was only providing _partial_ support, as the `noarchive` directive can be expressed in different ways (meta tag, HTTP headers, robots.txt file ...), most of which likely fall outside of the scope of Scoop.

We've decided to retire the current implementation of this feature for the time being. This PR removes the proxy _"hook"_ which was analyzing responses on the fly for that purpose. I expect captures to consume slightly less resources as a result of this removal. 

---

## Misc
- Playwright was updated to 1.37.0 (https://github.com/microsoft/playwright/releases/tag/v1.37.0)