### PR TITLE
Potential fixes for attachment capture edge cases 

### DIFF
--- a/Scoop.js
+++ b/Scoop.js
@@ -1215,7 +1215,7 @@ export class Scoop {
         .update(await readFile(this.options.ytDlpPath))
         .digest('hex')
 
-      cripHash = `sha256:${cripHash}`
+      ytDlpHash = `sha256:${ytDlpHash}`
     } catch (err) {
       this.log.warn('Could not compute SHA256 hash of yt-dlp executable')
       this.log.trace(err)

--- a/intercepters/ScoopProxy.js
+++ b/intercepters/ScoopProxy.js
@@ -81,7 +81,7 @@ export class ScoopProxy extends ScoopIntercepter {
 
   /**
    * Attempts to close the proxy server. Skips after X seconds if unable to do so.
-   * @returns {Promise<void>}
+   * @returns {Promise<boolean>}
    */
   teardown () {
     let closeTimeout = null
@@ -91,16 +91,16 @@ export class ScoopProxy extends ScoopIntercepter {
         // server.close does not close keep-alive connections so do so here
         this.#connection.closeAllConnections()
         this.#connection.close(() => {
-          this.capture.log.info('TCP-Proxy-Server closed')
           clearTimeout(closeTimeout)
-          resolve()
+          this.capture.log.info('TCP-Proxy-Server closed')
+          resolve(true)
         })
       }),
 
       new Promise(resolve => {
         closeTimeout = setTimeout(() => {
-          this.capture.log.warn('TCP-Proxy-Server did not close properly.')
-          resolve()
+          this.capture.log.warn('TCP-Proxy-Server did not close properly')
+          resolve(false)
         }, 5000)
       })
     ])

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@harvard-lil/portal": "^0.0.2",
         "@laverdet/beaugunderson-ip-address": "^8.1.0",
         "@playwright/browser-chromium": "^1.39.0",
-        "browsertrix-behaviors": "^0.5.0-beta.0",
+        "browsertrix-behaviors": "0.5.2",
         "chalk": "^5.2.0",
         "commander": "^11.0.0",
         "get-os-info": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@harvard-lil/portal": "^0.0.2",
     "@laverdet/beaugunderson-ip-address": "^8.1.0",
     "@playwright/browser-chromium": "^1.39.0",
-    "browsertrix-behaviors": "^0.5.0-beta.0",
+    "browsertrix-behaviors": "0.5.2",
     "chalk": "^5.2.0",
     "commander": "^11.0.0",
     "get-os-info": "^1.0.2",


### PR DESCRIPTION
**Observed behavior:** In some cases, capturing attachments such as screenshots or provenance summaries takes much longer than usually observed, and ends up failing. This can be problematic in scenarios in which one of these attachments is expected to be reliably delivered.  
Diagnosis is not entirely clear at this stage, but a combination of excess pressure from browser behaviors and a potential memory leak at proxy level might be involved.

While we look into addressing these issues more in depth, the following fixes should help account for them in production settings:
- Enforcing a 5 sec timeout on screenshots (default is 30 seconds). 
- Enforcing a 2.5 sec timeout on "scroll up" step
- Making sure `alwaysRun` steps don't stop if `captureTimeout` kicks in 
- Rely on Scoop's internal state vs the browser to grab user agent 
- Use `curl` with hard timeout for IP retrieval