### PR TITLE
Adds handling for EACCES/EADDRINUSE error on proxy init

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -411,6 +411,11 @@ program.action(async (name, options, command) => {
   try {
     url = command.processedArgs[0]
     capture = await Scoop.capture(url, options)
+
+    // A failed capture should make the CLI bail
+    if (!capture || capture?.state === Scoop.states.FAILED) {
+      throw new Error()
+    }
   } catch (err) {
     // Logs are handled by Scoop directly, unless `Scoop.capture` fails during initialization
     if (!capture) {

--- a/intercepters/ScoopProxy.js
+++ b/intercepters/ScoopProxy.js
@@ -50,8 +50,8 @@ export class ScoopProxy extends ScoopIntercepter {
         .on('connected', this.onConnected.bind(this))
         .on('response', this.onResponse.bind(this))
         .on('error', (err, serverRequest, clientRequest) => {
-          // Special handling of EACCES on init
-          if (!connected && err && err?.code === 'EACCES') {
+          // Special handling of EACCES/EADDRINUSE on init
+          if (!connected && err && ['EACCES', 'EADDRINUSE'].includes(err?.code)) {
             reject(new Error('TCP-Proxy-Server was unable to access port'))
           }
 


### PR DESCRIPTION
This PR adds error handling to `ScoopProxy` so the proxy errors out clearly when trying to initialize on a port that is already in use or otherwise unaccessible.

Many thanks to @rebeccacremona for the bug report!