### PR TITLE
Add detail to error logs

### DIFF
--- a/Scoop.js
+++ b/Scoop.js
@@ -22,6 +22,7 @@ import * as intercepters from './intercepters/index.js'
 import * as exporters from './exporters/index.js'
 import * as importers from './importers/index.js'
 import { filterOptions, defaults } from './options.js'
+import { formatErrorMessage } from './utils/formatErrorMessage.js'
 
 nunjucks.configure(CONSTANTS.TEMPLATES_PATH)
 
@@ -441,7 +442,7 @@ export class Scoop {
       this.log.info(`🍨 Starting capture of ${this.url}.`)
       this.state = Scoop.states.CAPTURE
     } catch (err) {
-      this.log.error('An error occurred during capture setup.')
+      this.log.error(`An error occurred during capture setup (${formatErrorMessage(err)}).`)
       this.log.trace(err)
       this.state = Scoop.states.FAILED
       return // exit early if the browser and proxy couldn't be launched
@@ -569,7 +570,7 @@ export class Scoop {
         await access(CONSTANTS.TMP_PATH, fsConstants.W_OK)
         tmpDirExists = true
       } catch (err) {
-        this.log.warn(`Error while creating base temporary folder ${CONSTANTS.TMP_PATH}.`)
+        this.log.warn(`Error while creating base temporary folder ${CONSTANTS.TMP_PATH} ((${formatErrorMessage(err)})).`)
         this.log.trace(err)
       }
     }

--- a/assets/fixtures/error.txt
+++ b/assets/fixtures/error.txt
@@ -1,0 +1,14 @@
+  browserType.launch:
+╔════════════════════════════════════════════════════════════════════════════════════════════════╗
+║ Looks like you launched a headed browser without having a XServer running.                     ║
+║ Set either 'headless: true' or use 'xvfb-run <your-playwright-app>' before running Playwright. ║
+║                                                                                                ║
+║ <3 Playwright Team                                                                             ║
+╚════════════════════════════════════════════════════════════════════════════════════════════════╝
+=========================== logs ===========================
+<launching> /root/.cache/ms-playwright/chromium-1084/chrome-linux/chrome --disable-field-trial-config --disable-background-networking --enable-features=NetworkService,NetworkServiceInProcess --disable-background-timer-throttling --disable-backgrounding-occluded-windows --disable-back-forward-cache --disable-breakpad --disable-client-side-phishing-detection --disable-component-extensions-with-background-pages --disable-component-update --no-default-browser-check --disable-default-apps --disable-dev-shm-usage --disable-extensions --disable-features=ImprovedCookieControls,LazyFrameLoading,GlobalMediaControls,DestroyProfileOnBrowserClose,MediaRouter,DialMediaRouteProvider,AcceptCHFrame,AutoExpandDetailsElement,CertificateTransparencyComponentUpdater,AvoidUnnecessaryBeforeUnloadCheckSync,Translate --allow-pre-commit-input --disable-hang-monitor --disable-ipc-flooding-protection --disable-popup-blocking --disable-prompt-on-repost --disable-renderer-backgrounding --force-color-profile=srgb --metrics-recording-only --no-first-run --enable-automation --password-store=basic --use-mock-keychain --no-service-autorun --export-tagged-pdf --disable-search-engine-choice-screen --no-sandbox --user-data-dir=/tmp/playwright_chromiumdev_profile-V405Mb --remote-debugging-pipe --no-startup-window
+<launched> pid=2188
+[pid=2188][err] [2188:2202:0202/222837.079996:ERROR:bus.cc(407)] Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
+[pid=2188][err] [2188:2188:0202/222837.088783:ERROR:ozone_platform_x11.cc(239)] Missing X server or $DISPLAY
+[pid=2188][err] [2188:2188:0202/222837.088827:ERROR:env.cc(255)] The platform failed to initialize.  Exiting.
+============================================================

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -8,6 +8,7 @@ import { Command, Option } from 'commander'
 
 import { Scoop } from '../Scoop.js'
 import { PACKAGE_INFO } from '../constants.js'
+import { formatErrorMessage } from '../utils/formatErrorMessage.js'
 
 /** @type {Command} */
 const program = new Command()
@@ -455,7 +456,7 @@ program.action(async (name, options, command) => {
     }
   } catch (err) {
     capture.log.trace(err)
-    capture.log.error(`Something went wrong while preparing ${options.output}. Use --log-level trace for details.`)
+    capture.log.error(`Something went wrong while preparing ${options.output} (${formatErrorMessage(err)}). Use --log-level trace for details.`)
     process.exit(1)
   }
 
@@ -467,7 +468,7 @@ program.action(async (name, options, command) => {
     capture.log.info(`${options.output} saved to disk.`)
   } catch (err) {
     capture.log.trace(err)
-    capture.log.error(`Something went wrong while saving ${options.output} to disk. Use --log-level trace for details.`)
+    capture.log.error(`Something went wrong while saving ${options.output} to disk (${formatErrorMessage(err)}). Use --log-level trace for details.`)
     process.exit(1)
   }
 
@@ -483,7 +484,7 @@ program.action(async (name, options, command) => {
       capture.log.info(`${jsonSummaryOutput} saved to disk.`)
     } catch (err) {
       capture.log.trace(err)
-      capture.log.error(`Something went wrong while saving ${jsonSummaryOutput} to disk. Use --log-level trace for details.`)
+      capture.log.error(`Something went wrong while saving ${jsonSummaryOutput} to disk (${formatErrorMessage(err)}). Use --log-level trace for details.`)
       process.exit(1)
     }
   }
@@ -504,7 +505,7 @@ program.action(async (name, options, command) => {
       }
     } catch (err) {
       capture.log.trace(err)
-      capture.log.error(`Something went wrong while exporting attachments to ${exportAttachmentsOutput}. Use --log-level trace for details.`)
+      capture.log.error(`Something went wrong while exporting attachments to ${exportAttachmentsOutput} (${formatErrorMessage(err)}). Use --log-level trace for details.`)
       process.exit(1)
     }
   }

--- a/exporters/scoopToWACZ.js
+++ b/exporters/scoopToWACZ.js
@@ -8,6 +8,7 @@ import { WARCParser } from 'warcio'
 import { Scoop } from '../Scoop.js'
 import * as CONSTANTS from '../constants.js'
 import { getHead } from '../utils/http.js'
+import { formatErrorMessage } from '../utils/formatErrorMessage.js'
 import { ScoopGeneratedExchange } from '../exchanges/ScoopGeneratedExchange.js'
 import { ScoopExchange } from '../exchanges/ScoopExchange.js' // eslint-disable-line
 
@@ -86,7 +87,7 @@ export async function scoopToWACZ (capture, includeRaw = false, signingServer) {
   } catch (err) {
     capture.log.trace(err)
     await clearOutputDir()
-    throw new Error('An error occurred while creating underlying WARC file.')
+    throw new Error(`An error occurred while creating underlying WARC file (${formatErrorMessage(err)}).`)
   }
 
   //
@@ -119,7 +120,7 @@ export async function scoopToWACZ (capture, includeRaw = false, signingServer) {
   } catch (err) {
     capture.log.trace(err)
     await clearOutputDir()
-    throw new Error('An error occurred while initializing WACZ output.')
+    throw new Error(`An error occurred while initializing WACZ output (${formatErrorMessage(err)}).`)
   }
 
   //
@@ -150,7 +151,7 @@ export async function scoopToWACZ (capture, includeRaw = false, signingServer) {
   } catch (err) {
     capture.log.trace(err)
     await clearOutputDir()
-    throw new Error('An error occurred while adding pages to WACZ output.')
+    throw new Error(`An error occurred while adding pages to WACZ output (${formatErrorMessage(err)}).`)
   }
 
   //
@@ -192,7 +193,7 @@ export async function scoopToWACZ (capture, includeRaw = false, signingServer) {
     } catch (err) {
       capture.log.trace(err)
       await clearOutputDir()
-      throw new Error('An error occurred while adding raw exchanges to WACZ output.')
+      throw new Error(`An error occurred while adding raw exchanges to WACZ output (${formatErrorMessage(err)}).`)
     }
   }
 
@@ -205,7 +206,7 @@ export async function scoopToWACZ (capture, includeRaw = false, signingServer) {
   } catch (err) {
     capture.log.trace(err)
     await clearOutputDir()
-    throw new Error('An error occurred while processing WACZ file.')
+    throw new Error(`An error occurred while processing WACZ file (${formatErrorMessage(err)}).`)
   }
 
   await clearOutputDir()

--- a/utils/formatErrorMessage.js
+++ b/utils/formatErrorMessage.js
@@ -1,0 +1,43 @@
+/**
+ * Produce a cleanly-formatted error message from a caught error:
+ * removes ANSI, collapses white space, and truncates at 100 chars.
+ *
+ * @param {*} err - An exception object, or anything else caught by try/catch.
+ * @param {boolean} [asciiOnly=true] - Whether to restrict output to the ASCII.
+ * @returns {string} A well-behaved message.
+ */
+export function formatErrorMessage (err, asciiOnly = true) {
+  let message
+
+  if (err instanceof Error) {
+    message = err.message
+  } else if (err instanceof String) {
+    message = err
+  } else {
+    message = String(err)
+  }
+
+  // strip ansi
+  // https://stackoverflow.com/a/29497680
+  const ansiRegex = /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g
+  message = message.replace(ansiRegex, '')
+
+  // reduce to ascii
+  // https://rosettacode.org/wiki/Strip_control_codes_and_extended_characters_from_a_string#JavaScript
+  if (asciiOnly) {
+    message = message.split('').filter(function (x) {
+      const n = x.charCodeAt(0)
+      return n > 31 && n < 127
+    }).join('')
+  }
+
+  // reduce all whitespace to single spaces
+  message = message.replace(/\s+/g, ' ').trim()
+
+  // truncate long messages
+  if (message.length > 100) {
+    message = `${message.substring(0, 100)}...`
+  }
+
+  return message
+}

--- a/utils/formatErrorMessage.js
+++ b/utils/formatErrorMessage.js
@@ -19,7 +19,7 @@ export function formatErrorMessage (err, asciiOnly = true) {
 
   // strip ansi
   // https://stackoverflow.com/a/29497680
-  const ansiRegex = /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g
+  const ansiRegex = /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g  //eslint-disable-line
   message = message.replace(ansiRegex, '')
 
   // reduce to ascii

--- a/utils/formatErrorMessage.test.js
+++ b/utils/formatErrorMessage.test.js
@@ -1,0 +1,68 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {formatErrorMessage} from './formatErrorMessage.js'
+
+test('formatErrorMessage should strip colors', async (_t) => {
+  try {
+    throw '\u001B[0m\u001B[4m\u001B[42m\u001B[31mfoo\u001B[39m\u001B[49m\u001B[24mfoo\u001B[0m';
+  } catch (err) {
+    assert(formatErrorMessage(err) == 'foofoo');
+  }
+})
+
+test('formatErrorMessage should truncate length', async (_t) => {
+  try {
+    throw 'a'.repeat(200);
+  } catch (err) {
+    assert(formatErrorMessage(err) == 'a'.repeat(100) + '...')
+  }
+})
+
+test('formatErrorMessage should strip block formatting', async (_t) => {
+  const actualErrorMessage = `
+      browserType.launch:
+    ╔════════════════════════════════════════════════════════════════════════════════════════════════╗
+    ║ Looks like you launched a headed browser without having a XServer running.                     ║
+    ║ Set either 'headless: true' or use 'xvfb-run <your-playwright-app>' before running Playwright. ║
+    ║                                                                                                ║
+    ║ <3 Playwright Team                                                                             ║
+    ╚════════════════════════════════════════════════════════════════════════════════════════════════╝
+    =========================== logs ===========================
+    <launching> /root/.cache/ms-playwright/chromium-1084/chrome-linux/chrome --disable-field-trial-config --disable-background-networking --enable-features=NetworkService,NetworkServiceInProcess --disable-background-timer-throttling --disable-backgrounding-occluded-windows --disable-back-forward-cache --disable-breakpad --disable-client-side-phishing-detection --disable-component-extensions-with-background-pages --disable-component-update --no-default-browser-check --disable-default-apps --disable-dev-shm-usage --disable-extensions --disable-features=ImprovedCookieControls,LazyFrameLoading,GlobalMediaControls,DestroyProfileOnBrowserClose,MediaRouter,DialMediaRouteProvider,AcceptCHFrame,AutoExpandDetailsElement,CertificateTransparencyComponentUpdater,AvoidUnnecessaryBeforeUnloadCheckSync,Translate --allow-pre-commit-input --disable-hang-monitor --disable-ipc-flooding-protection --disable-popup-blocking --disable-prompt-on-repost --disable-renderer-backgrounding --force-color-profile=srgb --metrics-recording-only --no-first-run --enable-automation --password-store=basic --use-mock-keychain --no-service-autorun --export-tagged-pdf --disable-search-engine-choice-screen --no-sandbox --user-data-dir=/tmp/playwright_chromiumdev_profile-V405Mb --remote-debugging-pipe --no-startup-window
+    <launched> pid=2188
+    [pid=2188][err] [2188:2202:0202/222837.079996:ERROR:bus.cc(407)] Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
+    [pid=2188][err] [2188:2188:0202/222837.088783:ERROR:ozone_platform_x11.cc(239)] Missing X server or $DISPLAY
+    [pid=2188][err] [2188:2188:0202/222837.088827:ERROR:env.cc(255)] The platform failed to initialize.  Exiting.
+    ============================================================).
+  `
+  try {
+    throw actualErrorMessage
+  } catch (err) {
+    assert(formatErrorMessage(err) == 'browserType.launch: Looks like you launched a headed browser without having a XServer running. Set e...');
+  }
+})
+
+test('formatErrorMessage handles arbitrary object', async (_t) => {
+  try {
+    throw NaN;
+  } catch (err) {
+   formatErrorMessage(err);
+  }
+})
+
+test('formatErrorMessage handles string', async (_t) => {
+  try {
+    throw 'hi';
+  } catch (err) {
+   assert(formatErrorMessage(err) == 'hi');
+  }
+})
+
+test('formatErrorMessage handles exception', async (_t) => {
+  try {
+    throw new Error ('hi');
+  } catch (err) {
+   assert(formatErrorMessage(err) == 'hi');
+  }
+})

--- a/utils/formatErrorMessage.test.js
+++ b/utils/formatErrorMessage.test.js
@@ -1,21 +1,21 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import {formatErrorMessage} from './formatErrorMessage.js'
+import { formatErrorMessage } from './formatErrorMessage.js'
 
 test('formatErrorMessage should strip colors', async (_t) => {
   try {
-    throw '\u001B[0m\u001B[4m\u001B[42m\u001B[31mfoo\u001B[39m\u001B[49m\u001B[24mfoo\u001B[0m';
+    throw '\u001B[0m\u001B[4m\u001B[42m\u001B[31mfoo\u001B[39m\u001B[49m\u001B[24mfoo\u001B[0m'
   } catch (err) {
-    assert(formatErrorMessage(err) == 'foofoo');
+    assert(formatErrorMessage(err) === 'foofoo')
   }
 })
 
 test('formatErrorMessage should truncate length', async (_t) => {
   try {
-    throw 'a'.repeat(200);
+    throw 'a'.repeat(200)
   } catch (err) {
-    assert(formatErrorMessage(err) == 'a'.repeat(100) + '...')
+    assert(formatErrorMessage(err) === 'a'.repeat(100) + '...')
   }
 })
 
@@ -39,30 +39,30 @@ test('formatErrorMessage should strip block formatting', async (_t) => {
   try {
     throw actualErrorMessage
   } catch (err) {
-    assert(formatErrorMessage(err) == 'browserType.launch: Looks like you launched a headed browser without having a XServer running. Set e...');
+    assert(formatErrorMessage(err) === 'browserType.launch: Looks like you launched a headed browser without having a XServer running. Set e...')
   }
 })
 
 test('formatErrorMessage handles arbitrary object', async (_t) => {
   try {
-    throw NaN;
+    throw NaN
   } catch (err) {
-   formatErrorMessage(err);
+    formatErrorMessage(err)
   }
 })
 
 test('formatErrorMessage handles string', async (_t) => {
   try {
-    throw 'hi';
+    throw 'hi'
   } catch (err) {
-   assert(formatErrorMessage(err) == 'hi');
+    assert(formatErrorMessage(err) === 'hi')
   }
 })
 
 test('formatErrorMessage handles exception', async (_t) => {
   try {
-    throw new Error ('hi');
+    throw new Error('hi')
   } catch (err) {
-   assert(formatErrorMessage(err) == 'hi');
+    assert(formatErrorMessage(err) === 'hi')
   }
 })

--- a/utils/formatErrorMessage.test.js
+++ b/utils/formatErrorMessage.test.js
@@ -1,6 +1,9 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
+import { readFile } from 'fs/promises'
+import { FIXTURES_PATH } from '../constants.js'
+
 import { formatErrorMessage } from './formatErrorMessage.js'
 
 test('formatErrorMessage should strip colors', async (_t) => {
@@ -20,22 +23,7 @@ test('formatErrorMessage should truncate length', async (_t) => {
 })
 
 test('formatErrorMessage should strip block formatting', async (_t) => {
-  const actualErrorMessage = `
-      browserType.launch:
-    ╔════════════════════════════════════════════════════════════════════════════════════════════════╗
-    ║ Looks like you launched a headed browser without having a XServer running.                     ║
-    ║ Set either 'headless: true' or use 'xvfb-run <your-playwright-app>' before running Playwright. ║
-    ║                                                                                                ║
-    ║ <3 Playwright Team                                                                             ║
-    ╚════════════════════════════════════════════════════════════════════════════════════════════════╝
-    =========================== logs ===========================
-    <launching> /root/.cache/ms-playwright/chromium-1084/chrome-linux/chrome --disable-field-trial-config --disable-background-networking --enable-features=NetworkService,NetworkServiceInProcess --disable-background-timer-throttling --disable-backgrounding-occluded-windows --disable-back-forward-cache --disable-breakpad --disable-client-side-phishing-detection --disable-component-extensions-with-background-pages --disable-component-update --no-default-browser-check --disable-default-apps --disable-dev-shm-usage --disable-extensions --disable-features=ImprovedCookieControls,LazyFrameLoading,GlobalMediaControls,DestroyProfileOnBrowserClose,MediaRouter,DialMediaRouteProvider,AcceptCHFrame,AutoExpandDetailsElement,CertificateTransparencyComponentUpdater,AvoidUnnecessaryBeforeUnloadCheckSync,Translate --allow-pre-commit-input --disable-hang-monitor --disable-ipc-flooding-protection --disable-popup-blocking --disable-prompt-on-repost --disable-renderer-backgrounding --force-color-profile=srgb --metrics-recording-only --no-first-run --enable-automation --password-store=basic --use-mock-keychain --no-service-autorun --export-tagged-pdf --disable-search-engine-choice-screen --no-sandbox --user-data-dir=/tmp/playwright_chromiumdev_profile-V405Mb --remote-debugging-pipe --no-startup-window
-    <launched> pid=2188
-    [pid=2188][err] [2188:2202:0202/222837.079996:ERROR:bus.cc(407)] Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
-    [pid=2188][err] [2188:2188:0202/222837.088783:ERROR:ozone_platform_x11.cc(239)] Missing X server or $DISPLAY
-    [pid=2188][err] [2188:2188:0202/222837.088827:ERROR:env.cc(255)] The platform failed to initialize.  Exiting.
-    ============================================================).
-  `
+  const actualErrorMessage = await readFile(`${FIXTURES_PATH}error.txt`)
   try {
     throw new Error(actualErrorMessage)
   } catch (err) {

--- a/utils/formatErrorMessage.test.js
+++ b/utils/formatErrorMessage.test.js
@@ -5,7 +5,7 @@ import { formatErrorMessage } from './formatErrorMessage.js'
 
 test('formatErrorMessage should strip colors', async (_t) => {
   try {
-    throw '\u001B[0m\u001B[4m\u001B[42m\u001B[31mfoo\u001B[39m\u001B[49m\u001B[24mfoo\u001B[0m'
+    throw new Error('\u001B[0m\u001B[4m\u001B[42m\u001B[31mfoo\u001B[39m\u001B[49m\u001B[24mfoo\u001B[0m')
   } catch (err) {
     assert(formatErrorMessage(err) === 'foofoo')
   }
@@ -13,7 +13,7 @@ test('formatErrorMessage should strip colors', async (_t) => {
 
 test('formatErrorMessage should truncate length', async (_t) => {
   try {
-    throw 'a'.repeat(200)
+    throw new Error('a'.repeat(200))
   } catch (err) {
     assert(formatErrorMessage(err) === 'a'.repeat(100) + '...')
   }
@@ -37,7 +37,7 @@ test('formatErrorMessage should strip block formatting', async (_t) => {
     ============================================================).
   `
   try {
-    throw actualErrorMessage
+    throw new Error(actualErrorMessage)
   } catch (err) {
     assert(formatErrorMessage(err) === 'browserType.launch: Looks like you launched a headed browser without having a XServer running. Set e...')
   }
@@ -45,7 +45,7 @@ test('formatErrorMessage should strip block formatting', async (_t) => {
 
 test('formatErrorMessage handles arbitrary object', async (_t) => {
   try {
-    throw NaN
+    throw new Error(NaN)
   } catch (err) {
     formatErrorMessage(err)
   }
@@ -53,7 +53,7 @@ test('formatErrorMessage handles arbitrary object', async (_t) => {
 
 test('formatErrorMessage handles string', async (_t) => {
   try {
-    throw 'hi'
+    throw 'hi'  //eslint-disable-line
   } catch (err) {
     assert(formatErrorMessage(err) === 'hi')
   }


### PR DESCRIPTION
Scoop is designed with [`loglevel`](https://www.npmjs.com/package/loglevel)'s debugging strategy in mind:
> disable all but error logging in production, and then run log.setLevel("trace") in your console to turn it all back on for a furious debugging session

This works great when running manually as a standalone utility, but is proving a little challenging when using Scoop as part of an orchestrated system, as we do with Perma.cc, which calls to a REST API that invokes Scoop: we occasionally see errors that we cannot reproduce locally on demand, and, because we lack the trace, we don't have a good sense of what's going wrong.

This PR attempts to sneak a reasonable amount of debugging information into the `ERROR` level logs, without cluttering them or compromising the logging philosophy.

It hopefully does not break anything.

It may not yet hit the sweet spot: it could be, the resulting log lines will prove messy. But, until I see some, I am not sure what else to strip away 🙂 