### PR TITLE
Dependency updates: yt-dlp, Playwright

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@harvard-lil/js-wacz": "^0.1.3",
         "@harvard-lil/portal": "^0.0.2",
         "@laverdet/beaugunderson-ip-address": "^8.1.0",
-        "@playwright/browser-chromium": "^1.45.2",
+        "@playwright/browser-chromium": "^1.45.3",
         "browsertrix-behaviors": "0.6.0",
         "chalk": "^5.2.0",
         "commander": "^12.0.0",
@@ -22,7 +22,7 @@
         "loglevel-plugin-prefix": "^0.8.4",
         "node-stream-zip": "^1.15.0",
         "nunjucks": "^3.2.3",
-        "playwright": "^1.45.2",
+        "playwright": "^1.45.3",
         "uuid": "^9.0.0",
         "warcio": "^2.1.0"
       },
@@ -391,12 +391,12 @@
       }
     },
     "node_modules/@playwright/browser-chromium": {
-      "version": "1.45.2",
-      "resolved": "https://registry.npmjs.org/@playwright/browser-chromium/-/browser-chromium-1.45.2.tgz",
-      "integrity": "sha512-oYWP32mCpEtPCE26uY+e82oF/oHa8y6Hx9EPN7ljrHyo6hb+/NDXp6OoJEZ/bwnGHEMKxfeD4yre0iXxBOLTxA==",
+      "version": "1.45.3",
+      "resolved": "https://registry.npmjs.org/@playwright/browser-chromium/-/browser-chromium-1.45.3.tgz",
+      "integrity": "sha512-UVPW8HveE8SghaahoMy8CfG0QdJ2mO0BZLOcPT8nlQh7Z97Gkv4e3Ad69D1oCqM3m3zYkDPAiGB+hOASNS0d/g==",
       "hasInstallScript": true,
       "dependencies": {
-        "playwright-core": "1.45.2"
+        "playwright-core": "1.45.3"
       },
       "engines": {
         "node": ">=18"
@@ -4293,11 +4293,11 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.45.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.2.tgz",
-      "integrity": "sha512-ReywF2t/0teRvNBpfIgh5e4wnrI/8Su8ssdo5XsQKpjxJj+jspm00jSoz9BTg91TT0c9HRjXO7LBNVrgYj9X0g==",
+      "version": "1.45.3",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.3.tgz",
+      "integrity": "sha512-QhVaS+lpluxCaioejDZ95l4Y4jSFCsBvl2UZkpeXlzxmqS+aABr5c82YmfMHrL6x27nvrvykJAFpkzT2eWdJww==",
       "dependencies": {
-        "playwright-core": "1.45.2"
+        "playwright-core": "1.45.3"
       },
       "bin": {
         "playwright": "cli.js"
@@ -4310,9 +4310,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.45.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.45.2.tgz",
-      "integrity": "sha512-ha175tAWb0dTK0X4orvBIqi3jGEt701SMxMhyujxNrgd8K0Uy5wMSwwcQHtyB4om7INUkfndx02XnQ2p6dvLDw==",
+      "version": "1.45.3",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.45.3.tgz",
+      "integrity": "sha512-+ym0jNbcjikaOwwSZycFbwkWgfruWvYlJfThKYAlImbxUgdWFO2oW70ojPm4OpE4t6TAo2FY/smM+hpVTtkhDA==",
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@harvard-lil/js-wacz": "^0.1.3",
     "@harvard-lil/portal": "^0.0.2",
     "@laverdet/beaugunderson-ip-address": "^8.1.0",
-    "@playwright/browser-chromium": "^1.45.2",
+    "@playwright/browser-chromium": "^1.45.3",
     "browsertrix-behaviors": "0.6.0",
     "chalk": "^5.2.0",
     "commander": "^12.0.0",
@@ -57,7 +57,7 @@
     "loglevel-plugin-prefix": "^0.8.4",
     "node-stream-zip": "^1.15.0",
     "nunjucks": "^3.2.3",
-    "playwright": "^1.45.2",
+    "playwright": "^1.45.3",
     "uuid": "^9.0.0",
     "warcio": "^2.1.0"
   },

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -3,8 +3,8 @@
 #-------------------------------------------------------------------------------
 mkdir ./executables/;
 
-# Pull yt-dlp (v2024.07.09)
-curl -L https://github.com/yt-dlp/yt-dlp/releases/download/2024.07.09/yt-dlp > ./executables/yt-dlp;
+# Pull yt-dlp (v2024.08.01)
+curl -L https://github.com/yt-dlp/yt-dlp/releases/download/2024.08.01/yt-dlp > ./executables/yt-dlp;
 chmod a+x ./executables/yt-dlp;
 
 # Pull crip (v2.1.0)


### PR DESCRIPTION
Includes the following updates:

* yt-dlp 2024.08.01 ([release](https://github.com/yt-dlp/yt-dlp/releases/tag/2024.08.01))
* Playwright 1.45.3 ([release](https://github.com/microsoft/playwright/releases/tag/v1.45.3))