### PR TITLE
add prev release version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harvard-lil/scoop",
-  "version": "0.6.26",
+  "version": "0.6.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@harvard-lil/scoop",
-      "version": "0.6.26",
+      "version": "0.6.27",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harvard-lil/scoop",
-  "version": "0.6.26",
+  "version": "0.6.27",
   "description": "🍨 High-fidelity, browser-based, single-page web archiving library and CLI.",
   "main": "Scoop.js",
   "type": "module",


### PR DESCRIPTION
It looks like the version of the last release (0.6.27) didn't make it to the repo. This PR updates it before I publish version 0.6.28 to NPM.