### PR TITLE
update playwright and yt-dlp versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@harvard-lil/js-wacz": "^0.1.3",
         "@harvard-lil/portal": "^0.0.2",
         "@laverdet/beaugunderson-ip-address": "^8.1.0",
-        "@playwright/browser-chromium": "^1.48.1",
+        "@playwright/browser-chromium": "^1.48.2",
         "browsertrix-behaviors": "0.6.0",
         "chalk": "^5.2.0",
         "commander": "^12.0.0",
@@ -22,7 +22,7 @@
         "loglevel-plugin-prefix": "^0.8.4",
         "node-stream-zip": "^1.15.0",
         "nunjucks": "^3.2.3",
-        "playwright": "^1.48.1",
+        "playwright": "^1.48.2",
         "uuid": "^9.0.0",
         "warcio": "^2.1.0"
       },
@@ -391,12 +391,12 @@
       }
     },
     "node_modules/@playwright/browser-chromium": {
-      "version": "1.48.1",
-      "resolved": "https://registry.npmjs.org/@playwright/browser-chromium/-/browser-chromium-1.48.1.tgz",
-      "integrity": "sha512-WNpIE+CpO4XNhdNTC/mVE8m/1gYR/hPswL8dnIZzElqxsOPm7qxIBdAChWm/7q1kkMiQ+gEGAaXXQfqL0vR28w==",
+      "version": "1.48.2",
+      "resolved": "https://registry.npmjs.org/@playwright/browser-chromium/-/browser-chromium-1.48.2.tgz",
+      "integrity": "sha512-TvYJ5PFaDPYNlKpvPSftBbPTnu75VdRKjoMjmkd7/P79rFIBD+v6K4wU8XR6PlAqqFdPcfLL5XXZnRwTRixbDQ==",
       "hasInstallScript": true,
       "dependencies": {
-        "playwright-core": "1.48.1"
+        "playwright-core": "1.48.2"
       },
       "engines": {
         "node": ">=18"
@@ -4321,11 +4321,11 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.48.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.48.1.tgz",
-      "integrity": "sha512-j8CiHW/V6HxmbntOfyB4+T/uk08tBy6ph0MpBXwuoofkSnLmlfdYNNkFTYD6ofzzlSqLA1fwH4vwvVFvJgLN0w==",
+      "version": "1.48.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.48.2.tgz",
+      "integrity": "sha512-NjYvYgp4BPmiwfe31j4gHLa3J7bD2WiBz8Lk2RoSsmX38SVIARZ18VYjxLjAcDsAhA+F4iSEXTSGgjua0rrlgQ==",
       "dependencies": {
-        "playwright-core": "1.48.1"
+        "playwright-core": "1.48.2"
       },
       "bin": {
         "playwright": "cli.js"
@@ -4338,9 +4338,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.48.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.48.1.tgz",
-      "integrity": "sha512-Yw/t4VAFX/bBr1OzwCuOMZkY1Cnb4z/doAFSwf4huqAGWmf9eMNjmK7NiOljCdLmxeRYcGPPmcDgU0zOlzP0YA==",
+      "version": "1.48.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.48.2.tgz",
+      "integrity": "sha512-sjjw+qrLFlriJo64du+EK0kJgZzoQPsabGF4lBvsid+3CNIZIYLgnMj9V6JY5VhM2Peh20DJWIVpVljLLnlawA==",
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@harvard-lil/js-wacz": "^0.1.3",
     "@harvard-lil/portal": "^0.0.2",
     "@laverdet/beaugunderson-ip-address": "^8.1.0",
-    "@playwright/browser-chromium": "^1.48.1",
+    "@playwright/browser-chromium": "^1.48.2",
     "browsertrix-behaviors": "0.6.0",
     "chalk": "^5.2.0",
     "commander": "^12.0.0",
@@ -57,7 +57,7 @@
     "loglevel-plugin-prefix": "^0.8.4",
     "node-stream-zip": "^1.15.0",
     "nunjucks": "^3.2.3",
-    "playwright": "^1.48.1",
+    "playwright": "^1.48.2",
     "uuid": "^9.0.0",
     "warcio": "^2.1.0"
   },

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -3,8 +3,8 @@
 #-------------------------------------------------------------------------------
 mkdir ./executables/;
 
-# Pull yt-dlp (v2024.10.07)
-curl -L https://github.com/yt-dlp/yt-dlp/releases/download/2024.10.07/yt-dlp > ./executables/yt-dlp;
+# Pull yt-dlp (v2024.10.22)
+curl -L https://github.com/yt-dlp/yt-dlp/releases/download/2024.10.22/yt-dlp > ./executables/yt-dlp;
 chmod a+x ./executables/yt-dlp;
 
 # Pull crip (v2.1.0)


### PR DESCRIPTION
Includes the following updates:

https://github.com/microsoft/playwright/releases/tag/v1.48.2
https://github.com/yt-dlp/yt-dlp/releases/tag/2024.10.22