### PR TITLE
Allow PDF capture in headful mode.

### DIFF
--- a/options.js
+++ b/options.js
@@ -127,11 +127,6 @@ export function filterOptions (newOptions = {}) {
     }
   }
 
-  // Check for invalid combinations
-  if (options.pdfSnapshot && !options.headless) {
-    throw new Error('"pdfSnapshot" option is only available in "headless" mode. Both options need to be "true".')
-  }
-
   // Check that paths are valid
   for (const toCheck of ['ytDlpPath', 'cripPath']) {
     if (!statSync(options[toCheck]).isFile()) {

--- a/options.test.js
+++ b/options.test.js
@@ -44,12 +44,6 @@ test('filterOptions entries are typecast based on defaults.', async (_t) => {
   }
 })
 
-test('filterOptions pdfSnapshot cannot be activated in headless mode.', async (_t) => {
-  assert.throws(() => {
-    filterOptions({ pdfSnapshot: true, headless: false })
-  })
-})
-
 test('filterOptions ytDlpPath must be a valid path to a file.', async (_t) => {
   assert.doesNotThrow(() => filterOptions()) // Default should not throw
 


### PR DESCRIPTION
**Background**

Our experiments, while limited, suggest that print-to-PDF works just fine with chromium in headful mode, even though [Playwright's docs](https://playwright.dev/docs/api/class-page#page-pdf) say, "Generating a pdf is currently only supported in Chromium headless", and their tests [only check headless chromium](https://github.com/microsoft/playwright/blob/main/tests/library/pdf.spec.ts)

Digging through their codebase and git history, I was unable to uncover any information about why: there are no Github issues mentioning it being flaky/unreliable/buggy; there are no PRs adding "experimental support" or the like; the Chrome dev tools protocol doesn't mention any restrictions in its [current verion](https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-printToPDF) OR in the oldest capture of that page in the Internet Archive...

I can see that the `pdf` method on Playwright's `Page` object [is optional](https://github.com/microsoft/playwright/blob/512645463e78a13943490a0c6c791ca7a0f6671d/packages/playwright-core/src/server/page.ts#L90) and may be [`undefined`](https://github.com/microsoft/playwright/blob/512645463e78a13943490a0c6c791ca7a0f6671d/packages/playwright-core/src/server/page.ts#L162), but I see no evidence that, if the method is available, that it is sometimes unreliable or untrusted (e.g., if running chromium in headful mode).

And, indeed, there is a [report](https://github.com/microsoft/playwright/issues/2206) from May 2020 where a user is complaining that `page.pdf` is throwing `TypeError: page.pdf is not a function`; they closed the issue when they heard that headful mode was not supported.

I think support for headful mode was added "by accident" due to some upstream change, and the docs and tests in the Playwright repo were never updated. 

**This PR**

This PR removes the init check that disallows running Scoop with `--pdf-snapshop` and `--headless false`.

While it is certainly possible there is some good reason for not running that way, and further communication with the Playwright team will uncover why, it seems low-risk to enable for now... and perhaps collect our own data / watch for errors.