### PR TITLE
Skip video summary production if yt-dlp fails silently

### DIFF
--- a/Scoop.js
+++ b/Scoop.js
@@ -911,7 +911,7 @@ export class Scoop {
 
       const dlpOptions = [
         '--dump-json', // Will return JSON meta data via stdout
-        '--no-simulate', // Forces download despites `--dump-json`
+        '--no-simulate', // Forces download despite `--dump-json`
         '--no-warnings', // Prevents pollution of stdout
         '--no-progress', // (Same as above)
         '--write-subs', // Try to pull subs

--- a/Scoop.js
+++ b/Scoop.js
@@ -1008,20 +1008,22 @@ export class Scoop {
         }
       }
 
-      if (metadataParsed.length) {
-        // Merge parsed metadata into a single JSON string and clean it before saving it
-        const metadataAsJSON = JSON
-          .stringify(metadataParsed, null, 2)
-          .replaceAll(this.captureTmpFolderPath, '')
-
-        const url = 'file:///video-extracted-metadata.json'
-        const httpHeaders = new Headers({ 'content-type': 'application/json' })
-        const body = Buffer.from(metadataAsJSON)
-        const isEntryPoint = false
-
-        this.addGeneratedExchange(url, httpHeaders, body, isEntryPoint)
-        metadataSaved = true
+      if (!metadataParsed.length) {
+        throw new Error('yt-dlp reported success (returned 0) but produced no metadata.')
       }
+
+      // Merge parsed metadata into a single JSON string and clean it before saving it
+      const metadataAsJSON = JSON
+        .stringify(metadataParsed, null, 2)
+        .replaceAll(this.captureTmpFolderPath, '')
+
+      const url = 'file:///video-extracted-metadata.json'
+      const httpHeaders = new Headers({ 'content-type': 'application/json' })
+      const body = Buffer.from(metadataAsJSON)
+      const isEntryPoint = false
+
+      this.addGeneratedExchange(url, httpHeaders, body, isEntryPoint)
+      metadataSaved = true
     } catch (err) {
       this.log.warn('Error while creating exchange for file:///video-extracted-medatadata.json.')
       this.log.trace(err)
@@ -1030,31 +1032,31 @@ export class Scoop {
     //
     // Generate summary page
     //
-    if (videoSaved || metadataSaved || subtitlesSaved) {
-      try {
-        const html = nunjucks.render('video-extracted-summary.njk', {
-          url: this.url,
-          now: new Date().toISOString(),
-          videoSaved,
-          metadataSaved,
-          subtitlesSaved,
-          availableVideosAndSubtitles,
-          metadataParsed
-        })
+    if ((videoSaved || metadataSaved || subtitlesSaved) === false) {
+      this.log.warn('yt-dlp reported success (returned 0), but produced no output.')
+      return
+    }
+    try {
+      const html = nunjucks.render('video-extracted-summary.njk', {
+        url: this.url,
+        now: new Date().toISOString(),
+        videoSaved,
+        metadataSaved,
+        subtitlesSaved,
+        availableVideosAndSubtitles,
+        metadataParsed
+      })
 
-        const url = 'file:///video-extracted-summary.html'
-        const httpHeaders = new Headers({ 'content-type': 'text/html' })
-        const body = Buffer.from(html)
-        const isEntryPoint = true
-        const description = `Extracted Video data from: ${this.url}`
+      const url = 'file:///video-extracted-summary.html'
+      const httpHeaders = new Headers({ 'content-type': 'text/html' })
+      const body = Buffer.from(html)
+      const isEntryPoint = true
+      const description = `Extracted Video data from: ${this.url}`
 
-        this.addGeneratedExchange(url, httpHeaders, body, isEntryPoint, description)
-      } catch (err) {
-        this.log.warn('Error while creating exchange for file:///video-extracted-summary.html.')
-        this.log.trace(err)
-      }
-    } else {
-      this.log.debug('Skipping creation of file:///video-extracted-summary.html; yt-dlp silently failed to produce output.')
+      this.addGeneratedExchange(url, httpHeaders, body, isEntryPoint, description)
+    } catch (err) {
+      this.log.warn('Error while creating exchange for file:///video-extracted-summary.html.')
+      this.log.trace(err)
     }
   }
 


### PR DESCRIPTION
**Background**

We recently started capturing with `--capture-video-as-attachment true` in Perma.cc. We found that quite frequently, `yt-dlp` is in fact failing to extract a video or retrieve any metadata about a video, but is still returning `0` as though it had succeeded.

Examples: 
- https://perma.cc/CY6E-4DTW?embed=False
- https://perma.cc/2LVU-7P27?embed=False

(Use the RWP side menu to view Pages, and navigate to "Extracted video data")
<img width="1421" alt="Screenshot 2024-11-04 at 4 04 41 PM" src="https://github.com/user-attachments/assets/fca2bcc5-e870-4b84-b780-6f5bfe557a21">
<img width="1421" alt="Screenshot 2024-11-04 at 4 04 50 PM" src="https://github.com/user-attachments/assets/4aec439c-60be-4586-a843-63fd162cc846">

**This PR**

This PR makes the tiniest of tweaks: 
- It checks to see if there's any metadata in the metadata file, so that we don't create an empty "generated exchange" when there isn't.
- It checks to see if any generated exchanges were added to the archive, either videos, subtitles, or video metadata files, before generating the video summary page, so that "empty" summaries aren't added to the WACZ.

I may not have added these tweaks idiomatically; happy to adjust in any way.