### PR TITLE
upgrade cross-spawn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "browsertrix-behaviors": "0.6.0",
         "chalk": "^5.2.0",
         "commander": "^12.0.0",
+        "cross-spawn": "^7.0.6",
         "get-os-info": "^1.0.2",
         "loglevel": "^1.8.1",
         "loglevel-plugin-prefix": "^0.8.4",
@@ -1149,9 +1150,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "browsertrix-behaviors": "0.6.0",
     "chalk": "^5.2.0",
     "commander": "^12.0.0",
+    "cross-spawn": "^7.0.6",
     "get-os-info": "^1.0.2",
     "loglevel": "^1.8.1",
     "loglevel-plugin-prefix": "^0.8.4",


### PR DESCRIPTION
Includes the following update:

https://github.com/moxystudio/node-cross-spawn/releases/tag/v7.0.6