### PR TITLE
Limit video attachment size

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Options:
   --capture-window-x <number>                            Width of the browser window Scoop will open to capture, in pixels. (default: 1600)
   --capture-window-y <number>                            Height of the browser window Scoop will open to capture, in pixels. (default: 900)
   --max-capture-size <number>                            Size limit for the capture's exchanges list, in bytes. (default: 209715200)
+  --max-video-capture-size <number>                      Size limit for the video attachment, in bytes. Scoop will not capture video attachments larger than this. (default: 209715200)
   --auto-scroll <bool>                                   Should Scoop try to scroll through the page? (choices: "true", "false", default: "true")
   --auto-play-media <bool>                               Should Scoop try to autoplay `<audio>` and `<video>` tags? (choices: "true", "false", default: "true")
   --grab-secondary-resources <bool>                      Should Scoop try to download img srcsets and secondary stylesheets? (choices: "true", "false", default: "true")

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -181,6 +181,13 @@ program.addOption(
     .default(defaults.maxCaptureSize)
 )
 
+program.addOption(
+  new Option(
+    '--max-video-capture-size <number>',
+    'Size limit for the video attachment, in bytes. Scoop will not capture video attachments larger than this.')
+    .default(defaults.maxVideoCaptureSize)
+)
+
 //
 // Behaviors
 //

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -100,7 +100,7 @@ program.addOption(
 program.addOption(
   new Option('--provenance-summary <bool>', 'Add provenance summary to capture?')
     .choices(['true', 'false'])
-    .default(String(defaults.captureVideoAsAttachment))
+    .default(String(defaults.provenanceSummary))
 )
 
 program.addOption(

--- a/options.js
+++ b/options.js
@@ -26,6 +26,7 @@ export const defaults = {
   captureWindowY: 900,
 
   maxCaptureSize: 200 * 1024 * 1024,
+  maxVideoCaptureSize: 200 * 1024 * 1024,
 
   autoScroll: true,
   autoPlayMedia: true,

--- a/options.types.js
+++ b/options.types.js
@@ -21,7 +21,9 @@
  * @property {number} captureWindowX=1600 - Browser window resolution in pixels: X axis.
  * @property {number} captureWindowY=900 - Browser window resolution in pixels: Y axis.
  *
- * @property {number} maxCaptureSize=209715200 - Maximum size, in bytes, for the exchanges list. Scoop stop intercepting exchanges at this threshold.
+ * @property {number} maxCaptureSize=209715200 - Maximum size, in bytes, for the exchanges list. Scoop stops intercepting exchanges at this threshold.
+ *
+ * @property {number} maxVideoCaptureSize=209715200 - Maximum size, in bytes, for video attachments. Scoop will not capture video attachments larger than this.
  *
  * @property {boolean} autoScroll=true - Should Scoop try to scroll through the page?
  * @property {boolean} autoPlayMedia=true - Should Scoop try to autoplay `<audio>` and `<video>` tags?

--- a/package-lock.json
+++ b/package-lock.json
@@ -3653,9 +3653,10 @@
       }
     },
     "node_modules/macos-release": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-3.2.0.tgz",
-      "integrity": "sha512-fSErXALFNsnowREYZ49XCdOHF8wOPWuFOGQrAhP7x5J/BqQv+B02cNsTykGpDgRVx43EKg++6ANmTaGTtW+hUA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-3.3.0.tgz",
+      "integrity": "sha512-tPJQ1HeyiU2vRruNGhZ+VleWuMQRro8iFtJxYgnS4NQe+EukKF6aGiIT+7flZhISAt2iaXBCfFGvAyif7/f8nQ==",
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },


### PR DESCRIPTION
This PR limits video attachment size to 200MB by default, and makes it configurable. See Linear issue LIL-2879 for some discussion. Initially, I thought we would truncate the video attachment at the specified size, but this is likely to be fussy, and I think would introduce a dependency on ffmpeg. As it stands, a primary video on a page that is larger than the setting will not be saved as an attachment.

Additionally, this PR corrects one default, and updates the package macos-release, so that developers using Sequoia can continue their work :) Thanks to @matteocargnelutti for the tip on the package update, and to @rebeccacremona for consultation.