### PR TITLE
push missing version update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harvard-lil/scoop",
-  "version": "0.6.37",
+  "version": "0.6.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@harvard-lil/scoop",
-      "version": "0.6.37",
+      "version": "0.6.38",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harvard-lil/scoop",
-  "version": "0.6.37",
+  "version": "0.6.38",
   "description": "🍨 High-fidelity, browser-based, single-page web archiving library and CLI.",
   "main": "Scoop.js",
   "type": "module",


### PR DESCRIPTION
It looks like the last time a new version was released to NPM, the new version number wasn't added to this repo. This is to fix that before I create release 0.6.39 for the yt-dlp upgrade. 