### PR TITLE
upgrade playwright and yt-dlp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@harvard-lil/js-wacz": "^0.1.6",
         "@harvard-lil/portal": "^0.0.2",
         "@laverdet/beaugunderson-ip-address": "^8.1.0",
-        "@playwright/browser-chromium": "^1.49.1",
+        "@playwright/browser-chromium": "^1.50.0",
         "browsertrix-behaviors": "0.6.0",
         "chalk": "^5.2.0",
         "commander": "^12.0.0",
@@ -22,7 +22,7 @@
         "loglevel-plugin-prefix": "^0.8.4",
         "node-stream-zip": "^1.15.0",
         "nunjucks": "^3.2.3",
-        "playwright": "^1.49.1",
+        "playwright": "^1.50.0",
         "uuid": "^9.0.0",
         "warcio": "^2.1.0"
       },
@@ -392,12 +392,12 @@
       }
     },
     "node_modules/@playwright/browser-chromium": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/@playwright/browser-chromium/-/browser-chromium-1.49.1.tgz",
-      "integrity": "sha512-LLeyllKSucbojsJBOpdJshwW27ZXZs3oypqffkVWLUvxX2azHJMOevsOcWpjCfoYbpevkaEozM2xHeSUGF00lg==",
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@playwright/browser-chromium/-/browser-chromium-1.50.0.tgz",
+      "integrity": "sha512-O2ZTMSArxJcBRfhUbcyzeZ4YLwwMCMINYJZIasDZQ3JBoI45m8ds4BSndvhpJGQrpyqI2tJHYooY+BIvlgI34w==",
       "hasInstallScript": true,
       "dependencies": {
-        "playwright-core": "1.49.1"
+        "playwright-core": "1.50.0"
       },
       "engines": {
         "node": ">=18"
@@ -4323,11 +4323,11 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
-      "integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.0.tgz",
+      "integrity": "sha512-+GinGfGTrd2IfX1TA4N2gNmeIksSb+IAe589ZH+FlmpV3MYTx6+buChGIuDLQwrGNCw2lWibqV50fU510N7S+w==",
       "dependencies": {
-        "playwright-core": "1.49.1"
+        "playwright-core": "1.50.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -4340,9 +4340,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
-      "integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.0.tgz",
+      "integrity": "sha512-CXkSSlr4JaZs2tZHI40DsZUN/NIwgaUPsyLuOAaIZp2CyF2sN5MM5NJsyB188lFSSozFxQ5fPT4qM+f0tH/6wQ==",
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@harvard-lil/js-wacz": "^0.1.6",
     "@harvard-lil/portal": "^0.0.2",
     "@laverdet/beaugunderson-ip-address": "^8.1.0",
-    "@playwright/browser-chromium": "^1.49.1",
+    "@playwright/browser-chromium": "^1.50.0",
     "browsertrix-behaviors": "0.6.0",
     "chalk": "^5.2.0",
     "commander": "^12.0.0",
@@ -57,7 +57,7 @@
     "loglevel-plugin-prefix": "^0.8.4",
     "node-stream-zip": "^1.15.0",
     "nunjucks": "^3.2.3",
-    "playwright": "^1.49.1",
+    "playwright": "^1.50.0",
     "uuid": "^9.0.0",
     "warcio": "^2.1.0"
   },

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -3,8 +3,8 @@
 #-------------------------------------------------------------------------------
 mkdir ./executables/;
 
-# Pull yt-dlp (v2025.01.15)
-curl -L https://github.com/yt-dlp/yt-dlp/releases/download/2025.01.15/yt-dlp > ./executables/yt-dlp;
+# Pull yt-dlp (v2025.01.26)
+curl -L https://github.com/yt-dlp/yt-dlp/releases/download/2025.01.26/yt-dlp > ./executables/yt-dlp;
 chmod a+x ./executables/yt-dlp;
 
 # Pull crip (v2.1.0)


### PR DESCRIPTION
Includes the following updates:

https://github.com/yt-dlp/yt-dlp/releases/tag/2025.01.26
https://github.com/microsoft/playwright/releases/tag/v1.50.0
