### PR TITLE
Resolve package.json bin warning when publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "Scoop.js",
   "type": "module",
   "bin": {
-    "scoop": "./bin/cli.js"
+    "scoop": "bin/cli.js"
   },
   "files": [
     "*.js",


### PR DESCRIPTION
NPM doesn't like it when the `bin` path in package.json is prepended with a `.`:

```sh
npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm warn publish errors corrected:
npm warn publish "bin[scoop]" script name was cleaned
```

This fixes the issue.